### PR TITLE
Radial base and rydberg state to coupling scheme

### DIFF
--- a/docs/examples/mqdt/mqdt_exp_qn.ipynb
+++ b/docs/examples/mqdt/mqdt_exp_qn.ipynb
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "e5b4c143",
    "metadata": {},
    "outputs": [
@@ -160,7 +160,7 @@
     "def get_label(state: rydstate.RydbergStateMQDT, qns: list[str]) -> str:\n",
     "    label = rf\"$\\left|\\nu={state.nu:.2f}\"\n",
     "    for qn in qns:\n",
-    "        exp_qn = state.angular.calc_exp_qn(qn)\n",
+    "        exp_qn = state.calc_exp_qn(qn)\n",
     "        label += rf\", {legend_labels[qn]}={exp_qn:.2f}\"\n",
     "    label += rf\", {legend_labels['f_tot']}=1/2 \\right\\rangle$\"\n",
     "    return label\n",
@@ -168,11 +168,11 @@
     "\n",
     "state = basis.states[97]\n",
     "label = get_label(state, [\"f_c\"])\n",
-    "ax.annotate(label, xy=(state.nu, state.angular.calc_exp_qn(\"f_c\")), xytext=(30, 1.1), **kwargs)\n",
+    "ax.annotate(label, xy=(state.nu, state.calc_exp_qn(\"f_c\")), xytext=(30, 1.1), **kwargs)\n",
     "\n",
     "state = basis.states[161]\n",
     "label = get_label(state, [\"j_tot\"])\n",
-    "ax.annotate(label, xy=(state.nu, state.angular.calc_exp_qn(\"j_tot\")), xytext=(110, 1.1), **kwargs)\n",
+    "ax.annotate(label, xy=(state.nu, state.calc_exp_qn(\"j_tot\")), xytext=(110, 1.1), **kwargs)\n",
     "\n",
     "fig.tight_layout()\n",
     "plt.show()"

--- a/docs/examples/radial/hydrogen_wavefunction.ipynb
+++ b/docs/examples/radial/hydrogen_wavefunction.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
     "    return r_list\n",
     "\n",
     "\n",
-    "sympy_r_list = calc_r_list(radial.nu, radial.potential.l_r, radial.x_list)\n",
+    "sympy_r_list = calc_r_list(radial.nu, radial.l_r, radial.x_list)\n",
     "sympy_u_list = sympy_r_list * radial.x_list\n",
     "sympy_w_list = sympy_u_list / np.sqrt(radial.z_list)"
    ]

--- a/src/rydstate/angular/angular_ket.py
+++ b/src/rydstate/angular/angular_ket.py
@@ -585,30 +585,21 @@ class AngularKetBase(ABC, Generic[GenericT_Unknown], metaclass=CachedABCMeta):
             if self.get_qn(q) != other.get_qn(q):
                 return 0.0
 
+        if any(is_unknown(qn) for qn in self.quantum_numbers) or any(is_unknown(qn) for qn in other.quantum_numbers):
+            return 0.0  # TODO, ignore Unknown contributions for now
+
         kets = [self, other]
 
         # JJ - FJ overlaps
         if any(isinstance(s, AngularKetJJ) for s in kets) and any(isinstance(s, AngularKetFJ) for s in kets):
             jj = next(s for s in kets if isinstance(s, AngularKetJJ))
             fj = next(s for s in kets if isinstance(s, AngularKetFJ))
-            if is_unknown(fj.j_r) or is_unknown(fj.j_c) or is_unknown(jj.j_tot) or is_unknown(fj.f_c):
-                raise RuntimeError("Cannot calculate overlap between JJ and FJ ket, due to Unknown quantum numbers.")
             return clebsch_gordan_6j(fj.j_r, fj.j_c, fj.i_c, jj.j_tot, fj.f_c, fj.f_tot)
 
         # JJ - LS overlaps
         if any(isinstance(s, AngularKetJJ) for s in kets) and any(isinstance(s, AngularKetLS) for s in kets):
             jj = next(s for s in kets if isinstance(s, AngularKetJJ))
             ls = next(s for s in kets if isinstance(s, AngularKetLS))
-            if (
-                is_unknown(ls.l_r)
-                or is_unknown(ls.l_c)
-                or is_unknown(ls.l_tot)
-                or is_unknown(ls.s_tot)
-                or is_unknown(jj.j_r)
-                or is_unknown(jj.j_c)
-                or is_unknown(jj.j_tot)
-            ):
-                raise RuntimeError("Cannot calculate overlap between JJ and LS ket, due to Unknown quantum numbers.")
             # NOTE: it matters, whether you first put all 3 l's and then all 3 s's or the other way round
             # (see symmetry properties of 9j symbol)
             # this convention is used, such that all matrix elements work out correctly, no matter in which
@@ -619,7 +610,7 @@ class AngularKetBase(ABC, Generic[GenericT_Unknown], metaclass=CachedABCMeta):
         if any(isinstance(s, AngularKetFJ) for s in kets) and any(isinstance(s, AngularKetLS) for s in kets):
             fj = next(s for s in kets if isinstance(s, AngularKetFJ))
             ls = next(s for s in kets if isinstance(s, AngularKetLS))
-            ov: float = 0
+            ov = 0.0
             for coeff, jj_ket in fj.to_state("JJ"):
                 ov += coeff * ls.calc_reduced_overlap(jj_ket)
             return float(ov)

--- a/src/rydstate/angular/angular_state.py
+++ b/src/rydstate/angular/angular_state.py
@@ -9,17 +9,24 @@ import numpy as np
 
 from rydstate.angular.angular_ket import (
     AngularKetBase,
-    AngularKetFJ,
-    AngularKetJJ,
-    AngularKetLS,
 )
-from rydstate.angular.utils import is_angular_momentum_quantum_number, is_not_set, is_unknown
+from rydstate.angular.utils import (
+    get_coupling_scheme_for_quantum_number,
+    is_angular_momentum_quantum_number,
+    is_not_set,
+    is_unknown,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
     from typing_extensions import Self
 
+    from rydstate.angular.angular_ket import (
+        AngularKetFJ,
+        AngularKetJJ,
+        AngularKetLS,
+    )
     from rydstate.angular.utils import AngularMomentumQuantumNumbers, AngularOperatorType, CouplingScheme, NotSet
     from rydstate.units import NDArray
 
@@ -151,9 +158,8 @@ class AngularState(Generic[GenericT_AngularKet]):
 
         """
         if q not in self.kets[0].quantum_number_names:
-            for ket_class in (AngularKetLS, AngularKetJJ, AngularKetFJ):
-                if q in ket_class.quantum_number_names:
-                    return self.to(ket_class.coupling_scheme).calc_exp_qn(q)
+            coupling_scheme = get_coupling_scheme_for_quantum_number(q)
+            return self.to(coupling_scheme).calc_exp_qn(q)
 
         qns = [ket.get_qn(q) for ket in self.kets]
         if all(q_val == qns[0] for q_val in qns):
@@ -180,9 +186,8 @@ class AngularState(Generic[GenericT_AngularKet]):
 
         """
         if q not in self.kets[0].quantum_number_names:
-            for ket_class in (AngularKetLS, AngularKetJJ, AngularKetFJ):
-                if q in ket_class.quantum_number_names:
-                    return self.to(ket_class.coupling_scheme).calc_std_qn(q)
+            coupling_scheme = get_coupling_scheme_for_quantum_number(q)
+            return self.to(coupling_scheme).calc_std_qn(q)
 
         qns = np.array([ket.get_qn(q) for ket in self.kets])
         if all(qn == qns[0] for qn in qns):
@@ -240,10 +245,8 @@ class AngularState(Generic[GenericT_AngularKet]):
         if isinstance(other, AngularKetBase):
             other = other.to_state()
         if is_angular_momentum_quantum_number(operator) and operator not in self.kets[0].quantum_number_names:
-            for ket_class in (AngularKetLS, AngularKetJJ, AngularKetFJ):
-                if operator in ket_class.quantum_number_names:
-                    state = self.to(ket_class.coupling_scheme)
-                    return state.calc_reduced_matrix_element(other, operator, kappa)
+            coupling_scheme = get_coupling_scheme_for_quantum_number(operator)
+            return self.to(coupling_scheme).calc_reduced_matrix_element(other, operator, kappa)
 
         if self.coupling_scheme != other.coupling_scheme:
             other = other.to(self.coupling_scheme)

--- a/src/rydstate/angular/angular_state.py
+++ b/src/rydstate/angular/angular_state.py
@@ -31,10 +31,7 @@ GenericT_AngularKet = TypeVar("GenericT_AngularKet", bound=AngularKetBase[Any])
 
 class AngularState(Generic[GenericT_AngularKet]):
     def __init__(self, coefficients: Sequence[float] | NDArray, kets: Sequence[GenericT_AngularKet]) -> None:
-        if np.isreal(coefficients).all():
-            coefficients = np.array(coefficients, dtype=float)
-        else:
-            coefficients = np.array(coefficients, dtype=complex)
+        coefficients = np.real_if_close(coefficients)
         self._coefficients: list[float] = coefficients.tolist()
         self.kets = kets
 

--- a/src/rydstate/angular/utils.py
+++ b/src/rydstate/angular/utils.py
@@ -166,6 +166,22 @@ def get_possible_quantum_number_values(
     return [float(s) for s in np.arange(abs(s_1 - s_2), s_1 + s_2 + 1, 1)]
 
 
+def get_coupling_scheme_for_quantum_number(qn: AngularMomentumQuantumNumbers) -> CouplingScheme:
+    """Return the coupling scheme, in which the given quantum number is a good quantum number."""
+    if qn in ("i_c", "s_c", "l_c", "s_r", "l_r", "f_tot"):
+        raise ValueError(
+            f"Quantum number {qn} is always a good quantum number, "
+            "callers should never invoke get_coupling_scheme_for_quantum_number for it."
+        )
+    if qn in ("s_tot", "l_tot", "j_tot"):
+        return "LS"
+    if qn in ("j_c", "j_r"):
+        return "JJ"
+    if qn in ("f_c",):  # noqa: FURB171
+        return "FJ"
+    raise ValueError(f"Invalid quantum number {qn} for coupling scheme.")
+
+
 @lru_cache(maxsize=1_000)
 def quantum_numbers_to_angular_ket(
     species: str,

--- a/src/rydstate/basis/basis_base.py
+++ b/src/rydstate/basis/basis_base.py
@@ -49,7 +49,7 @@ class BasisBase(ABC, Generic[_RydbergState]):
         if is_angular_momentum_quantum_number(qn):
             new_states: list[_RydbergState] = []
             for state in self.states:
-                qn_value = state.angular.calc_exp_qn(qn)
+                qn_value = state.calc_exp_qn(qn)
                 if is_unknown(qn_value):
                     if keep_unknown:
                         new_states.append(state)

--- a/src/rydstate/basis/basis_base.py
+++ b/src/rydstate/basis/basis_base.py
@@ -8,14 +8,14 @@ import numpy as np
 from typing_extensions import Self
 
 from rydstate.angular.utils import is_angular_momentum_quantum_number, is_unknown
-from rydstate.rydberg_state.rydberg_base import RydbergStateBase
+from rydstate.rydberg_state.rydberg_base import RydbergState
 from rydstate.species import get_element_properties
 from rydstate.units import ureg
 
 if TYPE_CHECKING:
     from rydstate.units import MatrixElementOperator, NDArray, PintArray, PintFloat
 
-_RydbergState = TypeVar("_RydbergState", bound=RydbergStateBase)
+_RydbergState = TypeVar("_RydbergState", bound=RydbergState)
 
 
 class BasisBase(ABC, Generic[_RydbergState]):
@@ -80,7 +80,7 @@ class BasisBase(ABC, Generic[_RydbergState]):
     def calc_std_qn(self, qn: str) -> NDArray:
         return np.array([state.calc_std_qn(qn) for state in self.states])
 
-    def calc_reduced_overlap(self, other: RydbergStateBase) -> NDArray:
+    def calc_reduced_overlap(self, other: RydbergState) -> NDArray:
         """Calculate the reduced overlap <self|other> (ignoring the magnetic quantum number m)."""
         return np.array([bra.calc_reduced_overlap(other) for bra in self.states])
 
@@ -94,16 +94,16 @@ class BasisBase(ABC, Generic[_RydbergState]):
 
     @overload
     def calc_reduced_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, unit: None = None
+        self, other: RydbergState, operator: MatrixElementOperator, unit: None = None
     ) -> PintArray: ...
 
     @overload
     def calc_reduced_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, unit: str
+        self, other: RydbergState, operator: MatrixElementOperator, unit: str
     ) -> NDArray: ...
 
     def calc_reduced_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, unit: str | None = None
+        self, other: RydbergState, operator: MatrixElementOperator, unit: str | None = None
     ) -> PintArray | NDArray:
         r"""Calculate the reduced matrix element :math:`\langle bra || O || other \rangle` for all states of self.
 

--- a/src/rydstate/basis/basis_mqdt.py
+++ b/src/rydstate/basis/basis_mqdt.py
@@ -205,7 +205,7 @@ def get_mqdt_states_from_fmodel(  # noqa: C901
         energy_au = model.calc_energy_au(nu)
         for m in get_m_range(model.f_tot, m_range):
             rydberg_kets = [
-                RydbergKet(angular_ket.replace_m(m), radial_ket)
+                RydbergKet(model.species, angular_ket.replace_m(m), radial_ket)
                 for angular_ket, radial_ket in zip(model.outer_channels, radial_kets, strict=True)
             ]
             states.append(

--- a/src/rydstate/basis/basis_mqdt.py
+++ b/src/rydstate/basis/basis_mqdt.py
@@ -10,9 +10,9 @@ from rydstate.angular.utils import NotSet, is_unknown
 from rydstate.basis.basis_base import BasisBase
 from rydstate.basis.utils import get_m_range, is_allowed_qn
 from rydstate.linalg import calc_nullvector, find_roots
-from rydstate.radial.radial_ket import RadialKet
+from rydstate.radial import RadialDummy, RadialKet
 from rydstate.rydberg_state import RydbergKet, RydbergStateMQDT
-from rydstate.species import MQDT, FModelSQDT, Potential, PotentialDummy, get_mqdt, get_potential_class
+from rydstate.species import MQDT, FModelSQDT, Potential, get_mqdt, get_potential_class
 
 if TYPE_CHECKING:
     from rydstate.species import FModel
@@ -194,13 +194,15 @@ def get_mqdt_states_from_fmodel(  # noqa: C901
         arg_max = np.argmax(np.abs(coefficients))
         coefficients *= np.sign(coefficients[arg_max])
 
-        radial_kets: list[RadialKet] = []
+        radial_kets: list[RadialKet | RadialDummy] = []
         for nui, angular_ket in zip(nuis, model.outer_channels, strict=True):
+            radial: RadialKet | RadialDummy
             if not is_unknown(angular_ket.l_r):
                 potential = potential_class(angular_ket.l_r)
+                radial = RadialKet(float(nui), potential, sign_convention="positive_at_outer_bound")
             else:
-                potential = PotentialDummy(model.species, angular_ket.l_r)
-            radial_kets.append(RadialKet(float(nui), potential, sign_convention="positive_at_outer_bound"))
+                radial = RadialDummy(1.0, nui)
+            radial_kets.append(radial)
 
         energy_au = model.calc_energy_au(nu)
         for m in get_m_range(model.f_tot, m_range):

--- a/src/rydstate/generate_database/generate_matrix_elements_table.py
+++ b/src/rydstate/generate_database/generate_matrix_elements_table.py
@@ -88,7 +88,7 @@ def generate_matrix_elements_tables(
                     matrix_elements[tkey].append((id_tuple[1], id_tuple[0], me))
 
         if free_memory:
-            state1.free_memory()
+            state1._free_memory()  # noqa: SLF001
 
     tables: dict[str, dict[str, list[int | float]]] = {}
     for tkey, mes in matrix_elements.items():

--- a/src/rydstate/generate_database/generate_matrix_elements_table.py
+++ b/src/rydstate/generate_database/generate_matrix_elements_table.py
@@ -40,7 +40,7 @@ def generate_matrix_elements_tables(
 
     basis.sort_states("nu")  # sort by nu == sort by energy
     list_of_id_state = list(enumerate(basis.states))
-    list_of_id_state = sorted(list_of_id_state, key=lambda x: (x[1].angular.calc_exp_qn("l_r"), x[1].nu, x[0]))
+    list_of_id_state = sorted(list_of_id_state, key=lambda x: (x[1].calc_exp_qn("l_r"), x[1].nu, x[0]))
 
     # precomupte l_r values for efficient k_angular_max filtering
     unknown_angular_kets = [

--- a/src/rydstate/generate_database/generate_matrix_elements_table.py
+++ b/src/rydstate/generate_database/generate_matrix_elements_table.py
@@ -8,7 +8,7 @@ from rydstate.units import MatrixElementOperatorRanks
 
 if TYPE_CHECKING:
     from rydstate.basis import BasisMQDT, BasisSQDT
-    from rydstate.rydberg_state.rydberg_base import RydbergStateBase
+    from rydstate.rydberg_state.rydberg_base import RydbergState
     from rydstate.units import MatrixElementOperator
 
 logger = logging.getLogger(__name__)
@@ -105,7 +105,7 @@ def generate_matrix_elements_tables(
 
 
 def calc_matrix_elements_one_pair(
-    initial: RydbergStateBase, final: RydbergStateBase, matrix_elements_of_interest: dict[str, MatrixElementOperator]
+    initial: RydbergState, final: RydbergState, matrix_elements_of_interest: dict[str, MatrixElementOperator]
 ) -> dict[str, float]:
     matrix_elements: dict[str, float] = {}
     for tkey, operator in matrix_elements_of_interest.items():

--- a/src/rydstate/generate_database/generate_states_table.py
+++ b/src/rydstate/generate_database/generate_states_table.py
@@ -73,17 +73,17 @@ def get_state_data(ids: int, state: RydbergStateBase) -> tuple[float | int | str
         state.nu,  # nu
         angular.f_tot,  # f_tot
         state.calc_exp_qn("nui"),  # exp_nui
-        angular.calc_exp_qn("l_tot"),  # exp_l
-        angular.calc_exp_qn("j_tot"),  # exp_j
-        angular.calc_exp_qn("s_tot"),  # exp_s
-        angular.calc_exp_qn("l_r"),  # exp_l_ryd
-        angular.calc_exp_qn("j_r"),  # exp_j_ryd = j for sqdt only one valence electron
+        state.calc_exp_qn("l_tot"),  # exp_l
+        state.calc_exp_qn("j_tot"),  # exp_j
+        state.calc_exp_qn("s_tot"),  # exp_s
+        state.calc_exp_qn("l_r"),  # exp_l_ryd
+        state.calc_exp_qn("j_r"),  # exp_j_ryd = j for sqdt only one valence electron
         state.calc_std_qn("nui"),  # std_nui = 0
-        angular.calc_std_qn("l_tot"),  # std_l
-        angular.calc_std_qn("j_tot"),  # std_j
-        angular.calc_std_qn("s_tot"),  # std_s
-        angular.calc_std_qn("l_r"),  # std_l_ryd
-        angular.calc_std_qn("j_r"),  # std_j_ryd
+        state.calc_std_qn("l_tot"),  # std_l
+        state.calc_std_qn("j_tot"),  # std_j
+        state.calc_std_qn("s_tot"),  # std_s
+        state.calc_std_qn("l_r"),  # std_l_ryd
+        state.calc_std_qn("j_r"),  # std_j_ryd
         bool(angular.i_c == 0),  # is_j_total_momentum
         bool(len(state.rydberg_kets) > 1),  # is_calculated_with_mqdt
         underspecified_channel_contribution,  # underspecified_channel_contribution = 0 for sqdt

--- a/src/rydstate/generate_database/generate_states_table.py
+++ b/src/rydstate/generate_database/generate_states_table.py
@@ -9,7 +9,7 @@ from rydstate.rydberg_state.rydberg_sqdt import RydbergStateSQDT
 
 if TYPE_CHECKING:
     from rydstate.basis import BasisMQDT, BasisSQDT
-    from rydstate.rydberg_state.rydberg_base import RydbergStateBase
+    from rydstate.rydberg_state.rydberg_base import RydbergState
 
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ def generate_states_table(
     return table
 
 
-def get_state_data(ids: int, state: RydbergStateBase) -> tuple[float | int | str | bool, ...]:
+def get_state_data(ids: int, state: RydbergState) -> tuple[float | int | str | bool, ...]:
     """Get the data for a given state as a tuple."""
     angular = state.angular_state
     underspecified_channel_contribution = sum(abs(coeff) ** 2 for coeff, ket in state if ket.angular.contains_unknown)

--- a/src/rydstate/generate_database/generate_states_table.py
+++ b/src/rydstate/generate_database/generate_states_table.py
@@ -60,7 +60,6 @@ def generate_states_table(
 
 def get_state_data(ids: int, state: RydbergState) -> tuple[float | int | str | bool, ...]:
     """Get the data for a given state as a tuple."""
-    angular = state.angular_state
     underspecified_channel_contribution = sum(abs(coeff) ** 2 for coeff, ket in state if ket.angular.contains_unknown)
 
     n = state.n if isinstance(state, RydbergStateSQDT) else 0
@@ -68,10 +67,10 @@ def get_state_data(ids: int, state: RydbergState) -> tuple[float | int | str | b
     data = (
         ids,  # id
         state.get_energy("a.u."),  # energy
-        angular.parity,  # parity = (-1)^l_tot
+        state.parity,  # parity = (-1)^l_tot
         n,  # n: quantum number
         state.nu,  # nu
-        angular.f_tot,  # f_tot
+        state.f_tot,  # f_tot
         state.calc_exp_qn("nui"),  # exp_nui
         state.calc_exp_qn("l_tot"),  # exp_l
         state.calc_exp_qn("j_tot"),  # exp_j
@@ -84,7 +83,7 @@ def get_state_data(ids: int, state: RydbergState) -> tuple[float | int | str | b
         state.calc_std_qn("s_tot"),  # std_s
         state.calc_std_qn("l_r"),  # std_l_ryd
         state.calc_std_qn("j_r"),  # std_j_ryd
-        bool(angular.i_c == 0),  # is_j_total_momentum
+        bool(state.element_properties.i_c == 0),  # is_j_total_momentum
         bool(len(state.rydberg_kets) > 1),  # is_calculated_with_mqdt
         underspecified_channel_contribution,  # underspecified_channel_contribution = 0 for sqdt
     )

--- a/src/rydstate/generate_database/generate_states_table.py
+++ b/src/rydstate/generate_database/generate_states_table.py
@@ -60,7 +60,7 @@ def generate_states_table(
 
 def get_state_data(ids: int, state: RydbergStateBase) -> tuple[float | int | str | bool, ...]:
     """Get the data for a given state as a tuple."""
-    angular = state.angular
+    angular = state.angular_state
     underspecified_channel_contribution = sum(abs(coeff) ** 2 for coeff, ket in state if ket.angular.contains_unknown)
 
     n = state.n if isinstance(state, RydbergStateSQDT) else 0

--- a/src/rydstate/radial/__init__.py
+++ b/src/rydstate/radial/__init__.py
@@ -1,8 +1,8 @@
-from rydstate.radial.radial_base import RadialBase
+from rydstate.radial.radial_base import Radial
 from rydstate.radial.radial_ket import RadialDummy, RadialKet
 
 __all__ = [
-    "RadialBase",
+    "Radial",
     "RadialDummy",
     "RadialKet",
 ]

--- a/src/rydstate/radial/__init__.py
+++ b/src/rydstate/radial/__init__.py
@@ -1,5 +1,8 @@
-from rydstate.radial.radial_ket import RadialKet
+from rydstate.radial.radial_base import RadialBase
+from rydstate.radial.radial_ket import RadialDummy, RadialKet
 
 __all__ = [
+    "RadialBase",
+    "RadialDummy",
     "RadialKet",
 ]

--- a/src/rydstate/radial/radial_base.py
+++ b/src/rydstate/radial/radial_base.py
@@ -207,9 +207,7 @@ class RadialBase:
             The radial matrix element in the desired unit.
 
         """
-        radial_matrix_element_au = calc_radial_matrix_element_from_w_z(
-            self.z_list, self.w_list, other.z_list, other.w_list, k_radial, integration_method
-        )
+        radial_matrix_element_au = self._calc_matrix_element_au(other, k_radial, integration_method=integration_method)
 
         if unit == "a.u.":
             return radial_matrix_element_au
@@ -217,3 +215,22 @@ class RadialBase:
         if unit is None:
             return radial_matrix_element
         return radial_matrix_element.to(unit).magnitude
+
+    def _calc_matrix_element_au(
+        self,
+        other: RadialBase,
+        k_radial: int,
+        *,
+        integration_method: INTEGRATION_METHODS = "sum",
+    ) -> float:
+        if self._is_dummy or other._is_dummy:
+            if self._is_dummy is not other._is_dummy:
+                return 0
+            if k_radial == 0 and abs(self.nu - other.nu) < 1e-10:  # type: ignore [attr-defined]
+                return self._coeff.conjugate() * other._coeff  # type: ignore [attr-defined,no-any-return]
+            # if not k_radial == 0 or nu are not the same we cant compute the matrix element and simply return 0
+            return 0
+
+        return calc_radial_matrix_element_from_w_z(
+            self.z_list, self.w_list, other.z_list, other.w_list, k_radial, integration_method
+        )

--- a/src/rydstate/radial/radial_base.py
+++ b/src/rydstate/radial/radial_base.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import logging
+import math
+from numbers import Number
+from typing import TYPE_CHECKING, overload
+
+import numpy as np
+
+from rydstate.radial.radial_matrix_element import calc_radial_matrix_element_from_w_z
+from rydstate.units import ureg
+
+if TYPE_CHECKING:
+    from rydstate.radial.radial_matrix_element import INTEGRATION_METHODS
+    from rydstate.units import NDArray, PintFloat
+
+logger = logging.getLogger(__name__)
+
+
+class RadialBase:
+    _z_list: NDArray
+    _w_list: NDArray
+    _is_dummy: bool = False
+
+    def __init__(self, z_list: NDArray, w_list: NDArray) -> None:
+        self._z_list = np.asarray(z_list)
+        self._w_list = np.asarray(w_list)
+
+        if len(z_list) < 2:
+            raise ValueError("z_list must have at least 2 elements")
+        if z_list[0] < 0 or self.dz < 0:
+            raise ValueError("z_list must be non-negative and increasing")
+        if len(w_list) != len(z_list):
+            raise ValueError("w_list must have the same length as z_list")
+        if not np.all(np.abs(np.diff(self.z_list) - self.dz) < 1e-10):
+            raise ValueError("z_list must be equidistantly spaced")
+        if not abs(round(self.z_list[0] / self.dz) - (self.z_list[0] / self.dz)) < 1e-8:
+            raise ValueError("z_list must start at an integer multiple of dz")
+        if np.isnan(self.w_list).any():
+            raise ValueError("w_list must not contain NaN values")
+
+    @property
+    def z_list(self) -> NDArray:
+        r"""The grid in the scaled dimensionless coordinate :math:`z = \sqrt{r/a_0}`.
+
+        In this coordinate the grid points are chosen equidistant,
+        because the nodes of the wavefunction are equally spaced in this coordinate.
+        """
+        return self._z_list
+
+    @property
+    def x_list(self) -> NDArray:
+        r"""The grid in the dimensionless coordinate :math:`x = r/a_0`."""
+        return self.z_list**2
+
+    @property
+    def dz(self) -> float:
+        r"""The grid step size in the scaled dimensionless coordinate :math:`z = \sqrt{r/a_0}`."""
+        return float(self.z_list[1] - self.z_list[0])
+
+    @property
+    def steps(self) -> int:
+        """The number of grid points."""
+        return len(self.z_list)
+
+    @property
+    def w_list(self) -> NDArray:
+        r"""The dimensionless scaled wavefunction :math:`w(z)`.
+
+        The scaled wavefunction is defined as
+
+        .. math::
+            w(z) = z^{-1/2} \tilde{u}(x=z^2) = (r/a_0)^{-1/4} \sqrt{a_0} r R(r)
+
+        """
+        return self._w_list
+
+    @property
+    def u_list(self) -> NDArray:
+        r"""The dimensionless wavefunction :math:`\tilde{u}(x) = \sqrt{a_0} r R(r)`."""
+        return np.sqrt(self.z_list) * self.w_list
+
+    @property
+    def r_list(self) -> NDArray:
+        r"""The radial wavefunction in atomic units :math:`\tilde{R}(r) = a_0^{-3/2} R(r)`."""
+        return self.u_list / self.x_list
+
+    @property
+    def norm(self) -> float:
+        """The norm of the wavefunction."""
+        return math.sqrt(2 * np.sum(np.abs(self.w_list) * np.abs(self.w_list) * self.z_list * self.z_list) * self.dz)
+
+    @property
+    def nodes(self) -> int:
+        """The number of nodes (i.e. zero-crossings) of the wavefunction."""
+        w_list_no_zeros = self.w_list[self.w_list != 0]
+        return int(np.sum(np.abs(np.diff(np.sign(w_list_no_zeros)))) // 2)
+
+    def _align(self, other: RadialBase) -> tuple[NDArray, NDArray, NDArray]:
+        """Zero-pad ``self`` and ``other`` onto a common grid covering both.
+
+        Returns ``(z_common, w_self, w_other)`` where all three arrays have the same length.
+        """
+        dz = self.dz
+        if abs(dz - other.dz) > 1e-10:
+            raise ValueError(f"Cannot combine radial states with different dz: {dz} != {other.dz}")
+
+        # integer offsets on the global grid [0, dz, 2*dz, ...]
+        i0_self = round(self.z_list[0] / dz)
+        i0_other = round(other.z_list[0] / dz)
+        lo = min(i0_self, i0_other)
+        hi = max(i0_self + len(self.z_list), i0_other + len(other.z_list))
+
+        # rebuild the common grid the same way RadialKet does, to keep identical float values
+        z_common = np.arange(0, hi * dz + dz / 2, dz)[lo:hi]
+
+        w_self = np.zeros(hi - lo, dtype=self.w_list.dtype)
+        w_self[i0_self - lo : i0_self - lo + len(self.w_list)] = self.w_list
+        w_other = np.zeros(hi - lo, dtype=other.w_list.dtype)
+        w_other[i0_other - lo : i0_other - lo + len(other.w_list)] = other.w_list
+
+        return z_common, w_self, w_other
+
+    def __add__(self, other: RadialBase) -> RadialBase:
+        if not isinstance(other, RadialBase):
+            return NotImplemented
+        z_common, w_self, w_other = self._align(other)
+        return RadialBase(z_common, w_self + w_other)
+
+    def __sub__(self, other: RadialBase) -> RadialBase:
+        return self.__add__(-other)
+
+    def __mul__(self, scalar: float) -> RadialBase:
+        if not isinstance(scalar, Number):
+            return NotImplemented
+        return RadialBase(self.z_list, scalar * self.w_list)
+
+    def __rmul__(self, scalar: float) -> RadialBase:
+        return self.__mul__(scalar)
+
+    def __truediv__(self, scalar: float) -> RadialBase:
+        return self.__mul__(1 / scalar)
+
+    def __neg__(self) -> RadialBase:
+        return self.__mul__(-1)
+
+    def get_outer_sign(self) -> int:
+        """Get the sign of the outermost non-zero value of the wavefunction."""
+        if self._is_dummy:
+            return int(np.sign(self._coeff))  # type: ignore [attr-defined]
+        for w in self.w_list[::-1]:
+            if w != 0:
+                return int(np.sign(w))
+        return 0
+
+    def calc_overlap(self, other: RadialBase, *, integration_method: INTEGRATION_METHODS = "sum") -> float:
+        r"""Calculate the overlap <self|other> of two radial kets.
+
+        Args:
+            other: Other radial ket
+            integration_method: Integration method to use
+
+        Returns:
+            The overlap integral between self and other.
+
+        """
+        return self.calc_matrix_element(other, k_radial=0, unit="a.u.", integration_method=integration_method)
+
+    @overload
+    def calc_matrix_element(
+        self, other: RadialBase, k_radial: int, *, unit: None = None, integration_method: INTEGRATION_METHODS = "sum"
+    ) -> PintFloat: ...
+
+    @overload
+    def calc_matrix_element(
+        self, other: RadialBase, k_radial: int, unit: str, *, integration_method: INTEGRATION_METHODS = "sum"
+    ) -> float: ...
+
+    def calc_matrix_element(
+        self,
+        other: RadialBase,
+        k_radial: int,
+        unit: str | None = None,
+        *,
+        integration_method: INTEGRATION_METHODS = "sum",
+    ) -> PintFloat | float:
+        r"""Calculate the radial matrix element <self | r^k_radial | other>.
+
+        Computes the integral
+
+        .. math::
+            \int_{0}^{\infty} dr r^2 r^k_{radial} R_1(r) R_2(r)
+            = a_0^{k_{radial}} \int_{0}^{\infty} dx x^k_{radial} \tilde{u}_1(x) \tilde{u}_2(x)
+            = a_0^{k_{radial}} \int_{0}^{\infty} dz 2 z^{2 + 2k_{radial}} w_1(z) w_2(z)
+
+        where R_1 and R_2 are the radial wavefunctions of self and other,
+        and w(z) = z^{-1/2} \tilde{u}(z^2) = (r/_a_0)^{1/4} \sqrt{a_0} r R(r).
+
+        Args:
+            other: Other radial ket
+            k_radial: Power of r in the matrix element
+                (default=0, this corresponds to the overlap integral \int dr r^2 R_1(r) R_2(r))
+            unit: Unit of the returned matrix element, default None returns a Pint quantity.
+            integration_method: Integration method to use
+
+        Returns:
+            The radial matrix element in the desired unit.
+
+        """
+        radial_matrix_element_au = calc_radial_matrix_element_from_w_z(
+            self.z_list, self.w_list, other.z_list, other.w_list, k_radial, integration_method
+        )
+
+        if unit == "a.u.":
+            return radial_matrix_element_au
+        radial_matrix_element: PintFloat = radial_matrix_element_au * ureg.Quantity(1, "a0") ** k_radial
+        if unit is None:
+            return radial_matrix_element
+        return radial_matrix_element.to(unit).magnitude

--- a/src/rydstate/radial/radial_base.py
+++ b/src/rydstate/radial/radial_base.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RadialBase:
+class Radial:
     _z_list: NDArray
     _w_list: NDArray
     _is_dummy: bool = False
@@ -96,7 +96,7 @@ class RadialBase:
         w_list_no_zeros = self.w_list[self.w_list != 0]
         return int(np.sum(np.abs(np.diff(np.sign(w_list_no_zeros)))) // 2)
 
-    def _align(self, other: RadialBase) -> tuple[NDArray, NDArray, NDArray]:
+    def _align(self, other: Radial) -> tuple[NDArray, NDArray, NDArray]:
         """Zero-pad ``self`` and ``other`` onto a common grid covering both.
 
         Returns ``(z_common, w_self, w_other)`` where all three arrays have the same length.
@@ -121,27 +121,27 @@ class RadialBase:
 
         return z_common, w_self, w_other
 
-    def __add__(self, other: RadialBase) -> RadialBase:
-        if not isinstance(other, RadialBase):
+    def __add__(self, other: Radial) -> Radial:
+        if not isinstance(other, Radial):
             return NotImplemented
         z_common, w_self, w_other = self._align(other)
-        return RadialBase(z_common, w_self + w_other)
+        return Radial(z_common, w_self + w_other)
 
-    def __sub__(self, other: RadialBase) -> RadialBase:
+    def __sub__(self, other: Radial) -> Radial:
         return self.__add__(-other)
 
-    def __mul__(self, scalar: float) -> RadialBase:
+    def __mul__(self, scalar: float) -> Radial:
         if not isinstance(scalar, Number):
             return NotImplemented
-        return RadialBase(self.z_list, scalar * self.w_list)
+        return Radial(self.z_list, scalar * self.w_list)
 
-    def __rmul__(self, scalar: float) -> RadialBase:
+    def __rmul__(self, scalar: float) -> Radial:
         return self.__mul__(scalar)
 
-    def __truediv__(self, scalar: float) -> RadialBase:
+    def __truediv__(self, scalar: float) -> Radial:
         return self.__mul__(1 / scalar)
 
-    def __neg__(self) -> RadialBase:
+    def __neg__(self) -> Radial:
         return self.__mul__(-1)
 
     def get_outer_sign(self) -> int:
@@ -153,7 +153,7 @@ class RadialBase:
                 return int(np.sign(w))
         return 0
 
-    def calc_overlap(self, other: RadialBase, *, integration_method: INTEGRATION_METHODS = "sum") -> float:
+    def calc_overlap(self, other: Radial, *, integration_method: INTEGRATION_METHODS = "sum") -> float:
         r"""Calculate the overlap <self|other> of two radial kets.
 
         Args:
@@ -168,17 +168,17 @@ class RadialBase:
 
     @overload
     def calc_matrix_element(
-        self, other: RadialBase, k_radial: int, *, unit: None = None, integration_method: INTEGRATION_METHODS = "sum"
+        self, other: Radial, k_radial: int, *, unit: None = None, integration_method: INTEGRATION_METHODS = "sum"
     ) -> PintFloat: ...
 
     @overload
     def calc_matrix_element(
-        self, other: RadialBase, k_radial: int, unit: str, *, integration_method: INTEGRATION_METHODS = "sum"
+        self, other: Radial, k_radial: int, unit: str, *, integration_method: INTEGRATION_METHODS = "sum"
     ) -> float: ...
 
     def calc_matrix_element(
         self,
-        other: RadialBase,
+        other: Radial,
         k_radial: int,
         unit: str | None = None,
         *,
@@ -218,7 +218,7 @@ class RadialBase:
 
     def _calc_matrix_element_au(
         self,
-        other: RadialBase,
+        other: Radial,
         k_radial: int,
         *,
         integration_method: INTEGRATION_METHODS = "sum",

--- a/src/rydstate/radial/radial_ket.py
+++ b/src/rydstate/radial/radial_ket.py
@@ -4,7 +4,7 @@ import logging
 import math
 import weakref
 from numbers import Number
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from mpmath import whitw
@@ -14,15 +14,13 @@ from rydstate.angular.utils import is_unknown
 from rydstate.metaclass_cache import CachedABCMeta
 from rydstate.radial.numerov import _run_numerov_integration_python, run_numerov_integration
 from rydstate.radial.radial_base import RadialBase
-from rydstate.radial.radial_matrix_element import calc_radial_matrix_element_from_w_z
 from rydstate.species.utils import calc_energy_from_nu
-from rydstate.units import ureg
 
 if TYPE_CHECKING:
     from rydstate.angular.utils import Unknown
     from rydstate.radial.radial_matrix_element import INTEGRATION_METHODS
     from rydstate.species.potential import Potential
-    from rydstate.units import NDArray, PintFloat
+    from rydstate.units import NDArray
 
 logger = logging.getLogger(__name__)
 
@@ -453,49 +451,29 @@ class RadialKet(RadialBase, metaclass=CachedABCMeta):
         else:
             raise ValueError(f"Unknown sign convention: {sign_convention}")
 
-    @overload
-    def calc_matrix_element(
-        self, other: RadialBase, k_radial: int, *, unit: None = None, integration_method: INTEGRATION_METHODS = "sum"
-    ) -> PintFloat: ...
-
-    @overload
-    def calc_matrix_element(
-        self, other: RadialBase, k_radial: int, unit: str, *, integration_method: INTEGRATION_METHODS = "sum"
-    ) -> float: ...
-
-    def calc_matrix_element(
+    def _calc_matrix_element_au(
         self,
         other: RadialBase,
         k_radial: int,
-        unit: str | None = None,
         *,
         integration_method: INTEGRATION_METHODS = "sum",
-    ) -> PintFloat | float:
+    ) -> float:
         if not isinstance(other, RadialKet):
-            return super().calc_matrix_element(
-                other, k_radial=k_radial, unit=unit, integration_method=integration_method
-            )
+            return super()._calc_matrix_element_au(other, k_radial=k_radial, integration_method=integration_method)
 
         if other not in self._matrix_element_cache and self in other._matrix_element_cache:  # noqa: SLF001
-            return other.calc_matrix_element(self, k_radial=k_radial, unit=unit, integration_method=integration_method)
+            return other._calc_matrix_element_au(self, k_radial=k_radial, integration_method=integration_method)  # noqa: SLF001
 
         cache = self._matrix_element_cache.get(other)
         if cache is None:
             cache = self._matrix_element_cache[other] = {}
         cache_key = (k_radial, integration_method)
         if cache_key not in cache:
-            cache[cache_key] = calc_radial_matrix_element_from_w_z(
-                self.z_list, self.w_list, other.z_list, other.w_list, k_radial, integration_method
+            cache[cache_key] = super()._calc_matrix_element_au(
+                other, k_radial=k_radial, integration_method=integration_method
             )
 
-        radial_matrix_element_au = cache[cache_key]
-
-        if unit == "a.u.":
-            return radial_matrix_element_au
-        radial_matrix_element: PintFloat = radial_matrix_element_au * ureg.Quantity(1, "a0") ** k_radial
-        if unit is None:
-            return radial_matrix_element
-        return radial_matrix_element.to(unit).magnitude
+        return cache[cache_key]
 
 
 class RadialDummy(RadialBase, metaclass=CachedABCMeta):

--- a/src/rydstate/radial/radial_ket.py
+++ b/src/rydstate/radial/radial_ket.py
@@ -13,7 +13,7 @@ from scipy.special import gamma
 from rydstate.angular.utils import is_unknown
 from rydstate.metaclass_cache import CachedABCMeta
 from rydstate.radial.numerov import _run_numerov_integration_python, run_numerov_integration
-from rydstate.radial.radial_base import RadialBase
+from rydstate.radial.radial_base import Radial
 from rydstate.species.utils import calc_energy_from_nu
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 WavefunctionSignConvention = Literal["positive_at_outer_bound", "n_l_1"] | None
 
 
-class RadialKet(RadialBase, metaclass=CachedABCMeta):
+class RadialKet(Radial, metaclass=CachedABCMeta):
     r"""Class representing a radial Rydberg state."""
 
     def __init__(
@@ -453,7 +453,7 @@ class RadialKet(RadialBase, metaclass=CachedABCMeta):
 
     def _calc_matrix_element_au(
         self,
-        other: RadialBase,
+        other: Radial,
         k_radial: int,
         *,
         integration_method: INTEGRATION_METHODS = "sum",
@@ -476,7 +476,7 @@ class RadialKet(RadialBase, metaclass=CachedABCMeta):
         return cache[cache_key]
 
 
-class RadialDummy(RadialBase, metaclass=CachedABCMeta):
+class RadialDummy(Radial, metaclass=CachedABCMeta):
     _is_dummy = True
 
     def __init__(self, coeff: float, nu: float) -> None:

--- a/src/rydstate/radial/radial_ket.py
+++ b/src/rydstate/radial/radial_ket.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import math
 import weakref
+from numbers import Number
 from typing import TYPE_CHECKING, Literal, overload
 
 import numpy as np
@@ -12,6 +13,7 @@ from scipy.special import gamma
 from rydstate.angular.utils import is_unknown
 from rydstate.metaclass_cache import CachedABCMeta
 from rydstate.radial.numerov import _run_numerov_integration_python, run_numerov_integration
+from rydstate.radial.radial_base import RadialBase
 from rydstate.radial.radial_matrix_element import calc_radial_matrix_element_from_w_z
 from rydstate.species.utils import calc_energy_from_nu
 from rydstate.units import ureg
@@ -19,7 +21,7 @@ from rydstate.units import ureg
 if TYPE_CHECKING:
     from rydstate.angular.utils import Unknown
     from rydstate.radial.radial_matrix_element import INTEGRATION_METHODS
-    from rydstate.species.potential import Potential, PotentialDummy
+    from rydstate.species.potential import Potential
     from rydstate.units import NDArray, PintFloat
 
 logger = logging.getLogger(__name__)
@@ -28,13 +30,13 @@ logger = logging.getLogger(__name__)
 WavefunctionSignConvention = Literal["positive_at_outer_bound", "n_l_1"] | None
 
 
-class RadialKet(metaclass=CachedABCMeta):
+class RadialKet(RadialBase, metaclass=CachedABCMeta):
     r"""Class representing a radial Rydberg state."""
 
     def __init__(
         self,
         nu: float,
-        potential: Potential | PotentialDummy,
+        potential: Potential,
         *,
         n_expected: int | None = None,
         dz: float = 1e-2,
@@ -95,6 +97,18 @@ class RadialKet(metaclass=CachedABCMeta):
         if self.n_expected is not None:
             self._sanity_check_n_expected(self.n_expected)
 
+    @property
+    def z_list(self) -> NDArray:
+        if not hasattr(self, "_z_list"):
+            self._create_grid_points()
+        return self._z_list
+
+    @property
+    def w_list(self) -> NDArray:
+        if not hasattr(self, "_w_list"):
+            self.integrate_wavefunction()
+        return self._w_list
+
     def _sanity_check_n_expected(self, n_expected: int) -> None:
         """Validate n_expected, which is used for additional sanity checks of the radial wavefunction.
 
@@ -123,67 +137,6 @@ class RadialKet(metaclass=CachedABCMeta):
     def l_r(self) -> int | Unknown:
         """Return the orbital quantum number of the rydberg electron."""
         return self.potential.l_r
-
-    @property
-    def z_list(self) -> NDArray:
-        r"""The grid in the scaled dimensionless coordinate :math:`z = \sqrt{r/a_0}`.
-
-        In this coordinate the grid points are chosen equidistant,
-        because the nodes of the wavefunction are equally spaced in this coordinate.
-        """
-        if not hasattr(self, "_z_list"):
-            self._create_grid_points()
-        return self._z_list
-
-    @property
-    def x_list(self) -> NDArray:
-        r"""The grid in the dimensionless coordinate :math:`x = r/a_0`."""
-        return self.z_list**2
-
-    @property
-    def dz(self) -> float:
-        r"""The grid step size in the scaled dimensionless coordinate :math:`z = \sqrt{r/a_0}`."""
-        return float(self.z_list[1] - self.z_list[0])
-
-    @property
-    def steps(self) -> int:
-        """The number of grid points."""
-        return len(self.z_list)
-
-    @property
-    def w_list(self) -> NDArray:
-        r"""The dimensionless scaled wavefunction :math:`w(z)`.
-
-        The scaled wavefunction is defined as
-
-        .. math::
-            w(z) = z^{-1/2} \tilde{u}(x=z^2) = (r/a_0)^{-1/4} \sqrt{a_0} r R(r)
-
-        """
-        if not hasattr(self, "_w_list"):
-            self.integrate_wavefunction()
-        return self._w_list
-
-    @property
-    def u_list(self) -> NDArray:
-        r"""The dimensionless wavefunction :math:`\tilde{u}(x) = \sqrt{a_0} r R(r)`."""
-        return np.sqrt(self.z_list) * self.w_list
-
-    @property
-    def r_list(self) -> NDArray:
-        r"""The radial wavefunction in atomic units :math:`\tilde{R}(r) = a_0^{-3/2} R(r)`."""
-        return self.u_list / self.x_list
-
-    @property
-    def norm(self) -> float:
-        """The norm of the wavefunction."""
-        return math.sqrt(2 * np.sum(self.w_list * self.w_list * self.z_list * self.z_list) * self.dz)
-
-    @property
-    def nodes(self) -> int:
-        """The number of nodes (i.e. zero-crossings) of the wavefunction."""
-        w_list_no_zeros = self.w_list[self.w_list != 0]
-        return int(np.sum(np.abs(np.diff(np.sign(w_list_no_zeros)))) // 2)
 
     def _create_grid_points(self) -> None:
         r"""Create the grid points for the integration of the radial Schrödinger equation.
@@ -487,12 +440,7 @@ class RadialKet(metaclass=CachedABCMeta):
         if sign_convention is None:
             return
 
-        current_outer_sign = 1
-        for w in self.w_list[::-1]:
-            if w != 0 and not np.isnan(w):
-                current_outer_sign = np.sign(w)
-                break
-
+        current_outer_sign = self.get_outer_sign()
         if sign_convention == "positive_at_outer_bound":
             if current_outer_sign < 0:
                 self._w_list = -self._w_list
@@ -505,61 +453,30 @@ class RadialKet(metaclass=CachedABCMeta):
         else:
             raise ValueError(f"Unknown sign convention: {sign_convention}")
 
-    def calc_overlap(self, other: RadialKet, *, integration_method: INTEGRATION_METHODS = "sum") -> float:
-        r"""Calculate the overlap <self|other> of two radial kets.
-
-        Args:
-            other: Other radial ket
-            integration_method: Integration method to use
-
-        Returns:
-            The overlap integral between self and other.
-
-        """
-        return self.calc_matrix_element(other, k_radial=0, unit="a.u.", integration_method=integration_method)
-
     @overload
     def calc_matrix_element(
-        self, other: RadialKet, k_radial: int, *, unit: None = None, integration_method: INTEGRATION_METHODS = "sum"
+        self, other: RadialBase, k_radial: int, *, unit: None = None, integration_method: INTEGRATION_METHODS = "sum"
     ) -> PintFloat: ...
 
     @overload
     def calc_matrix_element(
-        self, other: RadialKet, k_radial: int, unit: str, *, integration_method: INTEGRATION_METHODS = "sum"
+        self, other: RadialBase, k_radial: int, unit: str, *, integration_method: INTEGRATION_METHODS = "sum"
     ) -> float: ...
 
     def calc_matrix_element(
         self,
-        other: RadialKet,
+        other: RadialBase,
         k_radial: int,
         unit: str | None = None,
         *,
         integration_method: INTEGRATION_METHODS = "sum",
     ) -> PintFloat | float:
-        r"""Calculate the radial matrix element <self | r^k_radial | other>.
+        if not isinstance(other, RadialKet):
+            return super().calc_matrix_element(
+                other, k_radial=k_radial, unit=unit, integration_method=integration_method
+            )
 
-        Computes the integral
-
-        .. math::
-            \int_{0}^{\infty} dr r^2 r^k_{radial} R_1(r) R_2(r)
-            = a_0^{k_{radial}} \int_{0}^{\infty} dx x^k_{radial} \tilde{u}_1(x) \tilde{u}_2(x)
-            = a_0^{k_{radial}} \int_{0}^{\infty} dz 2 z^{2 + 2k_{radial}} w_1(z) w_2(z)
-
-        where R_1 and R_2 are the radial wavefunctions of self and other,
-        and w(z) = z^{-1/2} \tilde{u}(z^2) = (r/_a_0)^{1/4} \sqrt{a_0} r R(r).
-
-        Args:
-            other: Other radial ket
-            k_radial: Power of r in the matrix element
-                (default=0, this corresponds to the overlap integral \int dr r^2 R_1(r) R_2(r))
-            unit: Unit of the returned matrix element, default None returns a Pint quantity.
-            integration_method: Integration method to use
-
-        Returns:
-            The radial matrix element in the desired unit.
-
-        """
-        if other not in self._matrix_element_cache and self in other._matrix_element_cache:
+        if other not in self._matrix_element_cache and self in other._matrix_element_cache:  # noqa: SLF001
             return other.calc_matrix_element(self, k_radial=k_radial, unit=unit, integration_method=integration_method)
 
         cache = self._matrix_element_cache.get(other)
@@ -579,3 +496,23 @@ class RadialKet(metaclass=CachedABCMeta):
         if unit is None:
             return radial_matrix_element
         return radial_matrix_element.to(unit).magnitude
+
+
+class RadialDummy(RadialBase, metaclass=CachedABCMeta):
+    _is_dummy = True
+
+    def __init__(self, coeff: float, nu: float) -> None:
+        self.nu = nu
+        self._coeff = coeff
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._coeff}, nu={self.nu})"
+
+    @property
+    def norm(self) -> float:
+        return abs(self._coeff)
+
+    def __mul__(self, scalar: float) -> RadialDummy:
+        if not isinstance(scalar, Number):
+            return NotImplemented
+        return RadialDummy(scalar * self._coeff, self.nu)

--- a/src/rydstate/radial/radial_ket.py
+++ b/src/rydstate/radial/radial_ket.py
@@ -17,7 +17,6 @@ from rydstate.radial.radial_base import Radial
 from rydstate.species.utils import calc_energy_from_nu
 
 if TYPE_CHECKING:
-    from rydstate.angular.utils import Unknown
     from rydstate.radial.radial_matrix_element import INTEGRATION_METHODS
     from rydstate.species.potential import Potential
     from rydstate.units import NDArray
@@ -77,6 +76,7 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
         )
 
         self.potential = potential
+        self.l_r = potential.l_r
 
         if not nu > 0:
             raise ValueError(f"nu must be larger than 0, but is {nu=}")
@@ -94,6 +94,10 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
         self.n_expected: int | None = n_expected
         if self.n_expected is not None:
             self._sanity_check_n_expected(self.n_expected)
+
+    def __repr__(self) -> str:
+        nu, potential = self.nu, self.potential
+        return f"{self.__class__.__name__}({nu=}, {potential=})"
 
     @property
     def z_list(self) -> NDArray:
@@ -127,15 +131,6 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
         if not is_unknown(self.l_r) and n_expected <= self.l_r:
             raise ValueError(f"n_expected must be larger than l_r, but {n_expected=}, l_r={self.l_r} for {self}")
 
-    def __repr__(self) -> str:
-        nu, potential = self.nu, self.potential
-        return f"{self.__class__.__name__}({nu=}, {potential=})"
-
-    @property
-    def l_r(self) -> int | Unknown:
-        """Return the orbital quantum number of the rydberg electron."""
-        return self.potential.l_r
-
     def _create_grid_points(self) -> None:
         r"""Create the grid points for the integration of the radial Schrödinger equation.
 
@@ -147,12 +142,11 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
         dz = self._dz
         if hasattr(self, "_z_list"):
             raise RuntimeError("The grid points were already created, you should not create them again.")
-        l_r = self.l_r if not is_unknown(self.l_r) else 0  # used for limit estimations
         if x_min is None:
             # we set z_min explicitly too small,
             # since the integration will automatically stop after the turning point,
             # and as soon as the wavefunction is close to zero
-            if l_r <= 10:
+            if self.l_r <= 10:
                 z_min = 0.0
             else:
                 # we use reduced_mass_au=1, which overestimates the energy
@@ -168,7 +162,7 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
         if x_max is None:
             # This is an empirical formula for the maximum value of the radial coordinate
             # it takes into account that for large n but small l the wavefunction is very extended
-            x_max = 2 * self.nu * (self.nu + 20 + (self.nu - l_r) / 4) + 5
+            x_max = 2 * self.nu * (self.nu + 20 + (self.nu - self.l_r) / 4) + 5
         z_max = math.sqrt(x_max)
 
         # put all grid points on a standard grid, i.e. [dz, 2*dz, 3*dz, ...]
@@ -228,8 +222,6 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
 
         if hasattr(self, "_w_list"):
             raise RuntimeError("The wavefunction was already integrated, you should not create it again.")
-        if is_unknown(self.l_r):
-            raise ValueError("Cannot integrate wavefunction for unknown l_r, please provide a l_r to the potential.")
 
         # Note: Inside this method we use y and x like it is used in the numerov function
         # and not like in the rest of this class, i.e. y = w(z) and x = z
@@ -284,8 +276,6 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
     def _integrate_whittaker(self) -> None:
         if hasattr(self, "_w_list"):
             raise RuntimeError("The wavefunction was already integrated, you should not create it again.")
-        if is_unknown(self.l_r):
-            raise ValueError("Cannot integrate wavefunction for unknown l_r, please provide a l_r to the potential.")
 
         logger.warning("Using Whittaker to get the wavefunction is not recommended! Use this only for comparison.")
 
@@ -394,9 +384,6 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
             )
 
         # Check the number of nodes
-        assert not is_unknown(self.l_r), (
-            "l_r should not be Unknown at this point, otherwise the integration would not work"
-        )
         nodes = self.nodes
         if self.n_expected is not None and nodes != self.n_expected - self.l_r - 1:
             warning_msgs.append(
@@ -443,7 +430,6 @@ class RadialKet(Radial, metaclass=CachedABCMeta):
             if current_outer_sign < 0:
                 self._w_list = -self._w_list
         elif sign_convention == "n_l_1":
-            assert not is_unknown(self.l_r), "l_r should not be Unknown at this point"
             if self.n_expected is None:
                 raise ValueError("n_expected must be given to apply the 'n_l_1' sign convention.")
             if current_outer_sign * (-1) ** (self.n_expected - self.l_r - 1) < 0:

--- a/src/rydstate/rydberg_state/__init__.py
+++ b/src/rydstate/rydberg_state/__init__.py
@@ -1,11 +1,11 @@
-from rydstate.rydberg_state.rydberg_base import RydbergStateBase
+from rydstate.rydberg_state.rydberg_base import RydbergState
 from rydstate.rydberg_state.rydberg_ket import RydbergKet
 from rydstate.rydberg_state.rydberg_mqdt import RydbergStateMQDT
 from rydstate.rydberg_state.rydberg_sqdt import RydbergStateSQDT, RydbergStateSQDTAlkali
 
 __all__ = [
     "RydbergKet",
-    "RydbergStateBase",
+    "RydbergState",
     "RydbergStateMQDT",
     "RydbergStateSQDT",
     "RydbergStateSQDTAlkali",

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -121,15 +121,17 @@ class RydbergState:
 
         return RydbergState(self.species, coefficients, rydberg_kets, nu=self.nu, energy_au=self._energy_au)
 
-    def free_memory(self) -> None:
+    def _free_memory(self) -> None:
         """Release the cached radial and angular data to reduce memory usage.
 
         This drops the references to the (potentially large) radial wavefunctions of the rydberg kets.
-        After calling this, matrix elements and overlaps can no longer be calculated for this state.
+        After calling this, matrix elements, overlaps and expectation values can no longer be calculated for this state.
         """
         for rydberg_ket in self.rydberg_kets:
             rydberg_ket.__dict__.pop("radial", None)
             rydberg_ket.__dict__.pop("angular", None)
+        self.__dict__.pop("rydberg_kets", None)
+        self.__dict__.pop("angular_state", None)
 
     @property
     def norm(self) -> float:

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import math
-from abc import ABC
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, overload
 
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RydbergStateBase(ABC):
+class RydbergState:
     species: str
     """The species of the Rydberg state."""
 
@@ -58,11 +57,11 @@ class RydbergStateBase(ABC):
         self._energy_au = float(energy_au)
 
         if len(rydberg_kets) == 0:
-            raise ValueError("RydbergStateBase must be initialized with at least one state.")
+            raise ValueError("RydbergState must be initialized with at least one state.")
         if len(coefficients) != len(rydberg_kets):
             raise ValueError("Length of coefficients and rydberg_kets must be the same.")
         if len(set(rydberg_kets)) != len(rydberg_kets):
-            raise ValueError("RydbergStateBase initialized with duplicate rydberg_kets.")
+            raise ValueError("RydbergState initialized with duplicate rydberg_kets.")
 
         if abs(self.norm - 1) > 1e-10:
             raise ValueError(
@@ -143,7 +142,7 @@ class RydbergStateBase(ABC):
             return energy
         return energy.to(unit, "spectroscopy").magnitude
 
-    def calc_reduced_overlap(self, other: RydbergStateBase) -> float:
+    def calc_reduced_overlap(self, other: RydbergState) -> float:
         """Calculate the reduced overlap <self|other> (ignoring the magnetic quantum number m)."""
         ov = 0.0
         for coeff1, ket1 in zip(self._coefficients_conjugate, self.rydberg_kets, strict=True):
@@ -153,16 +152,14 @@ class RydbergStateBase(ABC):
 
     @overload
     def calc_reduced_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, unit: None = None
+        self, other: RydbergState, operator: MatrixElementOperator, unit: None = None
     ) -> PintFloat: ...
 
     @overload
-    def calc_reduced_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, unit: str
-    ) -> float: ...
+    def calc_reduced_matrix_element(self, other: RydbergState, operator: MatrixElementOperator, unit: str) -> float: ...
 
     def calc_reduced_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, unit: str | None = None
+        self, other: RydbergState, operator: MatrixElementOperator, unit: str | None = None
     ) -> PintFloat | float:
         r"""Calculate the reduced matrix element.
 
@@ -198,16 +195,14 @@ class RydbergStateBase(ABC):
 
     @overload
     def calc_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, q: int, unit: None = None
+        self, other: RydbergState, operator: MatrixElementOperator, q: int, unit: None = None
     ) -> PintFloat: ...
 
     @overload
-    def calc_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, q: int, unit: str
-    ) -> float: ...
+    def calc_matrix_element(self, other: RydbergState, operator: MatrixElementOperator, q: int, unit: str) -> float: ...
 
     def calc_matrix_element(
-        self, other: RydbergStateBase, operator: MatrixElementOperator, q: int, unit: str | None = None
+        self, other: RydbergState, operator: MatrixElementOperator, q: int, unit: str | None = None
     ) -> PintFloat | float:
         r"""Calculate the matrix element.
 

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -9,7 +9,12 @@ from scipy.special import exprel
 
 from rydstate.angular.angular_ket import AngularKetBase
 from rydstate.angular.angular_state import AngularState
-from rydstate.angular.utils import is_angular_momentum_quantum_number, is_not_set, is_unknown
+from rydstate.angular.utils import (
+    get_coupling_scheme_for_quantum_number,
+    is_angular_momentum_quantum_number,
+    is_not_set,
+    is_unknown,
+)
 from rydstate.rydberg_state.rydberg_ket import RydbergKet
 from rydstate.units import BaseQuantities, ureg
 
@@ -267,6 +272,9 @@ class RydbergState:
             return self.nu
 
         if is_angular_momentum_quantum_number(qn):
+            if qn not in self.rydberg_kets[0].angular.quantum_number_names:
+                coupling_scheme = get_coupling_scheme_for_quantum_number(qn)
+                return self.to_coupling_scheme(coupling_scheme).calc_exp_qn(qn)
             return self.angular_state.calc_exp_qn(qn)
 
         raise ValueError(f"Unknown quantum number {qn}")
@@ -276,6 +284,9 @@ class RydbergState:
             return 0
 
         if is_angular_momentum_quantum_number(qn):
+            if qn not in self.rydberg_kets[0].angular.quantum_number_names:
+                coupling_scheme = get_coupling_scheme_for_quantum_number(qn)
+                return self.to_coupling_scheme(coupling_scheme).calc_std_qn(qn)
             return self.angular_state.calc_std_qn(qn)
 
         raise ValueError(f"Unknown quantum number {qn}")

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -11,6 +11,7 @@ from scipy.special import exprel
 from rydstate.angular.angular_ket import AngularKetBase
 from rydstate.angular.angular_state import AngularState
 from rydstate.angular.utils import is_angular_momentum_quantum_number, is_not_set, is_unknown
+from rydstate.rydberg_state.rydberg_ket import RydbergKet
 from rydstate.units import BaseQuantities, ureg
 
 if TYPE_CHECKING:
@@ -18,7 +19,8 @@ if TYPE_CHECKING:
 
     from typing_extensions import Self
 
-    from rydstate.rydberg_state.rydberg_ket import RydbergKet
+    from rydstate.angular.utils import CouplingScheme
+    from rydstate.radial import Radial
     from rydstate.units import MatrixElementOperator, NDArray, PintArray, PintFloat
 
 
@@ -84,6 +86,40 @@ class RydbergState:
 
     def __iter__(self) -> Iterator[tuple[float, RydbergKet]]:
         return zip(self._coefficients, self.rydberg_kets, strict=True)
+
+    def to_coupling_scheme(self, coupling_scheme: CouplingScheme) -> RydbergState:
+        """Convert the Rydberg state to a different coupling scheme.
+
+        Args:
+            coupling_scheme: The coupling scheme to which to convert the Rydberg state.
+
+        Returns:
+            The Rydberg state in the new coupling scheme.
+
+        """
+        angular_ket: AngularKetBase[Any]
+        angular_radial_wf: dict[AngularKetBase[Any], Radial] = {}
+        for coeff_r, rydberg_ket in self:
+            angular_state = rydberg_ket.angular.to_state(coupling_scheme)
+            for coeff_a, angular_ket in angular_state:
+                if angular_ket in angular_radial_wf:
+                    angular_radial_wf[angular_ket] += (coeff_r * coeff_a) * rydberg_ket.radial
+                else:
+                    angular_radial_wf[angular_ket] = (coeff_r * coeff_a) * rydberg_ket.radial
+
+        rydberg_kets: list[RydbergKet] = []
+        coefficients: list[float] = []
+        for angular_ket, radial_wf in angular_radial_wf.items():
+            norm = radial_wf.norm
+            if norm < 1e-12:
+                # if channels cancel almost completely, we ignore them to avoid numerical issues
+                continue
+            outer_sign = radial_wf.get_outer_sign()
+            rydberg_ket = RydbergKet(self.species, angular_ket, radial_wf / (outer_sign * norm))
+            rydberg_kets.append(rydberg_ket)
+            coefficients.append(outer_sign * norm)
+
+        return RydbergState(self.species, coefficients, rydberg_kets, nu=self.nu, energy_au=self._energy_au)
 
     def free_memory(self) -> None:
         """Release the cached radial and angular data to reduce memory usage.

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -15,7 +15,7 @@ from rydstate.angular.utils import is_angular_momentum_quantum_number, is_not_se
 from rydstate.units import BaseQuantities, ureg
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
     from typing_extensions import Self
 
@@ -34,8 +34,6 @@ class RydbergStateBase(ABC):
     """The channel coefficients of the different RydbergKets that form the RydbergState stored as plain list."""
     rydberg_kets: list[RydbergKet]
     """The Rydberg kets that form the Rydberg state."""
-    angular: AngularKetBase[Any] | AngularState[Any]
-    """The angular part of the Rydberg state, i.e. the radial part is traced out."""
 
     nu: float
     """The effective principal quantum number nu.
@@ -45,11 +43,45 @@ class RydbergStateBase(ABC):
     _energy_au: float
     """The energy of the Rydberg state in atomic units (Hartree)."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        species: str,
+        coefficients: Sequence[float] | NDArray,
+        rydberg_kets: Sequence[RydbergKet],
+        nu: float,
+        energy_au: float,
+    ) -> None:
+        self.species = species
+        self._coefficients = np.asarray(coefficients).tolist()
+        self.rydberg_kets = list(rydberg_kets)
+        self.nu = float(nu)
+        self._energy_au = float(energy_au)
+
+        if len(rydberg_kets) == 0:
+            raise ValueError("RydbergStateBase must be initialized with at least one state.")
+        if len(coefficients) != len(rydberg_kets):
+            raise ValueError("Length of coefficients and rydberg_kets must be the same.")
+        if len(set(rydberg_kets)) != len(rydberg_kets):
+            raise ValueError("RydbergStateBase initialized with duplicate rydberg_kets.")
+
         if abs(self.norm - 1) > 1e-10:
             raise ValueError(
-                f"RydbergState initialized with non-normalized coefficients: {self._coefficients}, {self.rydberg_kets}"
+                "RydbergState initialized with non-normalized coefficients: "
+                f"{self.norm=} {self.coefficients=}, {self.rydberg_kets=}"
             )
+
+    def __repr__(self) -> str:
+        terms = [f"{coeff}*{rydberg_ket!r}" for coeff, rydberg_ket in self]
+        return f"{self.__class__.__name__}({', '.join(terms)})"
+
+    def __str__(self) -> str:
+        terms = [f"{coeff}*{rydberg_ket!s}" for coeff, rydberg_ket in self]
+        return f"{', '.join(terms)}"
+
+    @cached_property
+    def angular_state(self) -> AngularState[Any]:
+        """The angular part of the Rydberg state, i.e. the radial part is traced out."""
+        return AngularState(self._coefficients, [ket.angular for ket in self.rydberg_kets])
 
     def __iter__(self) -> Iterator[tuple[float, RydbergKet]]:
         return zip(self._coefficients, self.rydberg_kets, strict=True)
@@ -208,7 +240,7 @@ class RydbergStateBase(ABC):
 
     def calc_exp_qn(self, qn: str) -> float:
         if is_angular_momentum_quantum_number(qn):
-            return self.angular.calc_exp_qn(qn)
+            return self.angular_state.calc_exp_qn(qn)
         if qn == "nu":
             return self.nu
         if qn == "n":
@@ -224,7 +256,7 @@ class RydbergStateBase(ABC):
 
     def calc_std_qn(self, qn: str) -> float:
         if is_angular_momentum_quantum_number(qn):
-            return self.angular.calc_std_qn(qn)
+            return self.angular_state.calc_std_qn(qn)
         if qn in ("n", "nu"):
             return 0
         if qn == "nui":
@@ -340,7 +372,7 @@ class RydbergStateBase(ABC):
         from rydstate.basis import BasisMQDT, BasisSQDT  # noqa: PLC0415
         from rydstate.rydberg_state import RydbergStateMQDT, RydbergStateSQDT  # noqa: PLC0415
 
-        m = self.angular.m
+        m = self.angular_state.m
         if is_not_set(m):
             raise RuntimeError("m quantum number must be defined to calculate transition rates.")
 
@@ -360,9 +392,9 @@ class RydbergStateBase(ABC):
                 potential_class=type(self.potential),
             )
         elif isinstance(self, RydbergStateMQDT):
-            assert isinstance(self.angular, AngularState)
+            assert isinstance(self.angular_state, AngularState)
             l_r_list = [
-                angular_ket.l_r for angular_ket in self.angular.to("LS").kets if not is_unknown(angular_ket.l_r)
+                angular_ket.l_r for angular_ket in self.angular_state.to("LS").kets if not is_unknown(angular_ket.l_r)
             ]
             basis = BasisMQDT(
                 self.species,

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -16,6 +16,7 @@ from rydstate.angular.utils import (
     is_unknown,
 )
 from rydstate.rydberg_state.rydberg_ket import RydbergKet
+from rydstate.species.element_properties import get_element_properties
 from rydstate.units import BaseQuantities, ureg
 
 if TYPE_CHECKING:
@@ -57,6 +58,8 @@ class RydbergState:
         energy_au: float,
     ) -> None:
         self.species = species
+        self.element_properties = get_element_properties(species)
+
         self._coefficients = np.asarray(coefficients).tolist()
         self.rydberg_kets = list(rydberg_kets)
         self.nu = float(nu)
@@ -75,6 +78,16 @@ class RydbergState:
                 f"{self.norm=} {self.coefficients=}, {self.rydberg_kets=}"
             )
 
+        self.f_tot = rydberg_kets[0].angular.f_tot
+        if not all(rydberg_ket.angular.f_tot == self.f_tot for rydberg_ket in rydberg_kets):
+            raise ValueError("All rydberg_kets must have the same f_tot.")
+        self.parity = rydberg_kets[0].angular.parity
+        if not all(rydberg_ket.angular.parity == self.parity for rydberg_ket in rydberg_kets):
+            raise ValueError("All rydberg_kets must have the same parity.")
+        self.m = rydberg_kets[0].angular.m
+        if not all(rydberg_ket.angular.m == self.m for rydberg_ket in rydberg_kets):
+            raise ValueError("All rydberg_kets must have the same m.")
+
     def __repr__(self) -> str:
         terms = [f"{coeff}*{rydberg_ket!r}" for coeff, rydberg_ket in self]
         return f"{self.__class__.__name__}({', '.join(terms)})"
@@ -82,11 +95,6 @@ class RydbergState:
     def __str__(self) -> str:
         terms = [f"{coeff}*{rydberg_ket!s}" for coeff, rydberg_ket in self]
         return f"{', '.join(terms)}"
-
-    @cached_property
-    def angular_state(self) -> AngularState[Any]:
-        """The angular part of the Rydberg state, i.e. the radial part is traced out."""
-        return AngularState(self._coefficients, [ket.angular for ket in self.rydberg_kets])
 
     def __iter__(self) -> Iterator[tuple[float, RydbergKet]]:
         return zip(self._coefficients, self.rydberg_kets, strict=True)
@@ -135,7 +143,6 @@ class RydbergState:
             rydberg_ket.__dict__.pop("radial", None)
             rydberg_ket.__dict__.pop("angular", None)
         self.__dict__.pop("rydberg_kets", None)
-        self.__dict__.pop("angular_state", None)
 
     @property
     def norm(self) -> float:
@@ -275,7 +282,8 @@ class RydbergState:
             if qn not in self.rydberg_kets[0].angular.quantum_number_names:
                 coupling_scheme = get_coupling_scheme_for_quantum_number(qn)
                 return self.to_coupling_scheme(coupling_scheme).calc_exp_qn(qn)
-            return self.angular_state.calc_exp_qn(qn)
+            angular_state = AngularState(self._coefficients, [ket.angular for ket in self.rydberg_kets])
+            return angular_state.calc_exp_qn(qn)
 
         raise ValueError(f"Unknown quantum number {qn}")
 
@@ -287,7 +295,8 @@ class RydbergState:
             if qn not in self.rydberg_kets[0].angular.quantum_number_names:
                 coupling_scheme = get_coupling_scheme_for_quantum_number(qn)
                 return self.to_coupling_scheme(coupling_scheme).calc_std_qn(qn)
-            return self.angular_state.calc_std_qn(qn)
+            angular_state = AngularState(self._coefficients, [ket.angular for ket in self.rydberg_kets])
+            return angular_state.calc_std_qn(qn)
 
         raise ValueError(f"Unknown quantum number {qn}")
 
@@ -393,7 +402,7 @@ class RydbergState:
         from rydstate.basis import BasisMQDT, BasisSQDT  # noqa: PLC0415
         from rydstate.rydberg_state import RydbergStateMQDT, RydbergStateSQDT  # noqa: PLC0415
 
-        m = self.angular_state.m
+        m = self.m
         if is_not_set(m):
             raise RuntimeError("m quantum number must be defined to calculate transition rates.")
 
@@ -413,9 +422,8 @@ class RydbergState:
                 potential_class=type(self.potential),
             )
         elif isinstance(self, RydbergStateMQDT):
-            assert isinstance(self.angular_state, AngularState)
             l_r_list = [
-                angular_ket.l_r for angular_ket in self.angular_state.to("LS").kets if not is_unknown(angular_ket.l_r)
+                ket.angular.l_r for ket in self.to_coupling_scheme("LS").rydberg_kets if not is_unknown(ket.angular.l_r)
             ]
             basis = BasisMQDT(
                 self.species,

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import math
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, overload
 
@@ -138,14 +137,6 @@ class RydbergState:
         """Return the norm of the state (should be 1)."""
         return float(np.linalg.norm(self._coefficients))
 
-    @property
-    def nui(self) -> list[float]:
-        """Return the effective principal quantum numbers nui of the different channels."""
-        nuis = [getattr(rydberg_ket.radial, "nu", None) for rydberg_ket in self.rydberg_kets]
-        if any(nui is None for nui in nuis):
-            raise ValueError("One or more radial wavefunctions do not have a 'nu' attribute.")
-        return nuis  # type: ignore [return-value]
-
     @cached_property
     def coefficients(self) -> NDArray:
         """Return the channel coefficients as numpy array."""
@@ -272,34 +263,20 @@ class RydbergState:
         return value
 
     def calc_exp_qn(self, qn: str) -> float:
-        if is_angular_momentum_quantum_number(qn):
-            return self.angular_state.calc_exp_qn(qn)
         if qn == "nu":
             return self.nu
-        if qn == "n":
-            n = getattr(self, "n", None)
-            if n is None:
-                raise ValueError(f"{self} has no quantum number n")
-            return n  # type: ignore [no-any-return]
-        if qn == "nui":
-            qns = np.array(self.nui)
-            coefficients2 = np.conjugate(self.coefficients) * self.coefficients / self.norm**2
-            return float(np.sum(coefficients2 * qns))
+
+        if is_angular_momentum_quantum_number(qn):
+            return self.angular_state.calc_exp_qn(qn)
+
         raise ValueError(f"Unknown quantum number {qn}")
 
     def calc_std_qn(self, qn: str) -> float:
+        if qn == "nu":
+            return 0
+
         if is_angular_momentum_quantum_number(qn):
             return self.angular_state.calc_std_qn(qn)
-        if qn in ("n", "nu"):
-            return 0
-        if qn == "nui":
-            qns = np.array(self.nui)
-            coefficients2 = np.conjugate(self.coefficients) * self.coefficients / self.norm**2
-            exp_q = np.sum(coefficients2 * qns)
-            exp_q2 = np.sum(coefficients2 * qns * qns)
-            if abs(exp_q2 - exp_q**2) < 1e-10:
-                return 0
-            return math.sqrt(exp_q2 - exp_q**2)
 
         raise ValueError(f"Unknown quantum number {qn}")
 

--- a/src/rydstate/rydberg_state/rydberg_base.py
+++ b/src/rydstate/rydberg_state/rydberg_base.py
@@ -72,7 +72,10 @@ class RydbergStateBase(ABC):
     @property
     def nui(self) -> list[float]:
         """Return the effective principal quantum numbers nui of the different channels."""
-        return [rydberg_ket.radial.nu for rydberg_ket in self.rydberg_kets]
+        nuis = [getattr(rydberg_ket.radial, "nu", None) for rydberg_ket in self.rydberg_kets]
+        if any(nui is None for nui in nuis):
+            raise ValueError("One or more radial wavefunctions do not have a 'nu' attribute.")
+        return nuis  # type: ignore [return-value]
 
     @cached_property
     def coefficients(self) -> NDArray:
@@ -214,7 +217,9 @@ class RydbergStateBase(ABC):
                 raise ValueError(f"{self} has no quantum number n")
             return n  # type: ignore [no-any-return]
         if qn == "nui":
-            return float(sum([abs(coeff) ** 2 * ket.radial.nu / self.norm**2 for coeff, ket in self]))
+            qns = np.array(self.nui)
+            coefficients2 = np.conjugate(self.coefficients) * self.coefficients / self.norm**2
+            return float(np.sum(coefficients2 * qns))
         raise ValueError(f"Unknown quantum number {qn}")
 
     def calc_std_qn(self, qn: str) -> float:

--- a/src/rydstate/rydberg_state/rydberg_ket.py
+++ b/src/rydstate/rydberg_state/rydberg_ket.py
@@ -8,7 +8,7 @@ from rydstate.units import MatrixElementOperatorRanks, ureg
 
 if TYPE_CHECKING:
     from rydstate.angular.angular_ket import AngularKetBase
-    from rydstate.radial.radial_base import RadialBase
+    from rydstate.radial.radial_base import Radial
     from rydstate.units import MatrixElementOperator, PintFloat
 
 
@@ -27,7 +27,7 @@ class RydbergKet:
         self,
         species: str,
         angular: AngularKetBase[Any],
-        radial: RadialBase,
+        radial: Radial,
     ) -> None:
         r"""Initialize the Rydberg state."""
         self.species = species

--- a/src/rydstate/rydberg_state/rydberg_ket.py
+++ b/src/rydstate/rydberg_state/rydberg_ket.py
@@ -4,12 +4,12 @@ import logging
 import math
 from typing import TYPE_CHECKING, Any, overload
 
-from rydstate.angular.utils import is_unknown
+from rydstate.radial import RadialDummy
 from rydstate.units import MatrixElementOperatorRanks, ureg
 
 if TYPE_CHECKING:
     from rydstate.angular.angular_ket import AngularKetBase
-    from rydstate.radial import RadialKet
+    from rydstate.radial.radial_base import RadialBase
     from rydstate.units import MatrixElementOperator, PintFloat
 
 
@@ -28,11 +28,9 @@ class RydbergKet:
         self,
         species: str,
         angular: AngularKetBase[Any],
-        radial: RadialKet,
+        radial: RadialBase,
     ) -> None:
         r"""Initialize the Rydberg state."""
-        if angular.l_r != radial.l_r:
-            raise ValueError("The radial ket must have the same l_r as the angular ket.")
         self.species = species
         self.angular = angular
         self.radial = radial
@@ -45,9 +43,9 @@ class RydbergKet:
 
     def calc_reduced_overlap(self, other: RydbergKet) -> float:
         """Calculate the reduced overlap <self|other> (ignoring the magnetic quantum number m)."""
-        if is_unknown(self.radial.l_r) and is_unknown(other.radial.l_r):
+        if isinstance(self.radial, RadialDummy) and isinstance(other.radial, RadialDummy):
             return 1 if abs(self.radial.nu - other.radial.nu) < 1e-10 else 0
-        if is_unknown(self.radial.l_r) or is_unknown(other.radial.l_r):
+        if isinstance(self.radial, RadialDummy) or isinstance(other.radial, RadialDummy):
             return 0
 
         angular_overlap = self.angular.calc_reduced_overlap(other.angular)
@@ -95,8 +93,8 @@ class RydbergKet:
                 f"Operator {operator} not supported, must be one of {list(MatrixElementOperatorRanks.keys())}."
             ) from err
 
-        if self.radial.potential.is_dummy or other.radial.potential.is_dummy:
-            # a dummy potential means the l_r of the channel is unknown, so no matrix element can be calculated
+        if self.radial._is_dummy or other.radial._is_dummy:  # noqa: SLF001
+            # no matrix element can be calculated for dummy radial wavefunctions, return 0
             return 0
 
         if operator == "magnetic_dipole":

--- a/src/rydstate/rydberg_state/rydberg_ket.py
+++ b/src/rydstate/rydberg_state/rydberg_ket.py
@@ -4,7 +4,6 @@ import logging
 import math
 from typing import TYPE_CHECKING, Any, overload
 
-from rydstate.radial import RadialDummy
 from rydstate.units import MatrixElementOperatorRanks, ureg
 
 if TYPE_CHECKING:
@@ -43,11 +42,6 @@ class RydbergKet:
 
     def calc_reduced_overlap(self, other: RydbergKet) -> float:
         """Calculate the reduced overlap <self|other> (ignoring the magnetic quantum number m)."""
-        if isinstance(self.radial, RadialDummy) and isinstance(other.radial, RadialDummy):
-            return 1 if abs(self.radial.nu - other.radial.nu) < 1e-10 else 0
-        if isinstance(self.radial, RadialDummy) or isinstance(other.radial, RadialDummy):
-            return 0
-
         angular_overlap = self.angular.calc_reduced_overlap(other.angular)
         if angular_overlap == 0:
             return 0
@@ -92,10 +86,6 @@ class RydbergKet:
             raise ValueError(
                 f"Operator {operator} not supported, must be one of {list(MatrixElementOperatorRanks.keys())}."
             ) from err
-
-        if self.radial._is_dummy or other.radial._is_dummy:  # noqa: SLF001
-            # no matrix element can be calculated for dummy radial wavefunctions, return 0
-            return 0
 
         if operator == "magnetic_dipole":
             # Magnetic dipole operator: mu = - mu_B (g_l <l_tot> + g_s <s_tot>)

--- a/src/rydstate/rydberg_state/rydberg_ket.py
+++ b/src/rydstate/rydberg_state/rydberg_ket.py
@@ -26,20 +26,22 @@ class RydbergKet:
 
     def __init__(
         self,
+        species: str,
         angular: AngularKetBase[Any],
         radial: RadialKet,
     ) -> None:
         r"""Initialize the Rydberg state."""
         if angular.l_r != radial.l_r:
             raise ValueError("The radial ket must have the same l_r as the angular ket.")
+        self.species = species
         self.angular = angular
         self.radial = radial
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.radial!r}, {self.angular!r})"
+        return f"{self.__class__.__name__}({self.species}, {self.radial!r}, {self.angular!r})"
 
     def __str__(self) -> str:
-        return f"({self.radial}, {self.angular})"
+        return f"({self.species}, {self.radial}, {self.angular})"
 
     def calc_reduced_overlap(self, other: RydbergKet) -> float:
         """Calculate the reduced overlap <self|other> (ignoring the magnetic quantum number m)."""

--- a/src/rydstate/rydberg_state/rydberg_mqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_mqdt.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
-
-from rydstate.angular import AngularKetFJ, AngularState
+from rydstate.angular import AngularKetFJ
 from rydstate.rydberg_state.rydberg_base import RydbergStateBase
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from rydstate.angular import AngularState
     from rydstate.rydberg_state.rydberg_ket import RydbergKet
     from rydstate.species import MQDT, Potential
     from rydstate.units import NDArray
@@ -20,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class RydbergStateMQDT(RydbergStateBase):
-    angular: AngularState[AngularKetFJ[Any]]
+    angular_state: AngularState[AngularKetFJ[Any]]
     """Return the angular part of the MQDT state as an AngularState."""
 
     def __init__(
@@ -33,31 +32,10 @@ class RydbergStateMQDT(RydbergStateBase):
         mqdt: MQDT,
         potential_class: type[Potential],
     ) -> None:
-        self.species = species
-        self._coefficients = np.asarray(coefficients).tolist()
-        self.rydberg_kets = list(rydberg_kets)
-        self.nu = float(nu)
-        self._energy_au = float(energy_au)
         self.mqdt = mqdt
         self.potential_class = potential_class
 
-        if len(rydberg_kets) == 0:
-            raise ValueError("RydbergStateMQDT must be initialized with at least one state.")
-        if len(coefficients) != len(rydberg_kets):
-            raise ValueError("Length of coefficients and rydberg_kets must be the same.")
         if not all(isinstance(rydberg_ket.angular, AngularKetFJ) for rydberg_ket in rydberg_kets):
             raise ValueError("All rydberg_kets must have an angular part of type AngularKetFJ.")
-        if len(set(rydberg_kets)) != len(rydberg_kets):
-            raise ValueError("RydbergStateMQDT initialized with duplicate rydberg_kets.")
 
-        self.angular = AngularState(self._coefficients, [ket.angular for ket in rydberg_kets])  # type: ignore [misc]
-
-        super().__init__()
-
-    def __repr__(self) -> str:
-        terms = [f"{coeff}*{rydberg_ket!r}" for coeff, rydberg_ket in self]
-        return f"{self.__class__.__name__}({', '.join(terms)})"
-
-    def __str__(self) -> str:
-        terms = [f"{coeff}*{rydberg_ket!s}" for coeff, rydberg_ket in self]
-        return f"{', '.join(terms)}"
+        super().__init__(species, coefficients, rydberg_kets, nu, energy_au)

--- a/src/rydstate/rydberg_state/rydberg_mqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_mqdt.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from rydstate.angular import AngularKetFJ
-from rydstate.rydberg_state.rydberg_base import RydbergStateBase
+from rydstate.rydberg_state.rydberg_base import RydbergState
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RydbergStateMQDT(RydbergStateBase):
+class RydbergStateMQDT(RydbergState):
     angular_state: AngularState[AngularKetFJ[Any]]
     """Return the angular part of the MQDT state as an AngularState."""
 

--- a/src/rydstate/rydberg_state/rydberg_mqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_mqdt.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from rydstate.angular import AngularKetFJ
 from rydstate.rydberg_state.rydberg_base import RydbergState
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from rydstate.angular import AngularState
     from rydstate.rydberg_state.rydberg_ket import RydbergKet
     from rydstate.species import MQDT, Potential
     from rydstate.units import NDArray
@@ -22,9 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 class RydbergStateMQDT(RydbergState):
-    angular_state: AngularState[AngularKetFJ[Any]]
-    """Return the angular part of the MQDT state as an AngularState."""
-
     def __init__(
         self,
         species: str,
@@ -37,9 +32,6 @@ class RydbergStateMQDT(RydbergState):
     ) -> None:
         self.mqdt = mqdt
         self.potential_class = potential_class
-
-        if not all(isinstance(rydberg_ket.angular, AngularKetFJ) for rydberg_ket in rydberg_kets):
-            raise ValueError("All rydberg_kets must have an angular part of type AngularKetFJ.")
 
         super().__init__(species, coefficients, rydberg_kets, nu, energy_au)
 

--- a/src/rydstate/rydberg_state/rydberg_mqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_mqdt.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING, Any
+
+import numpy as np
 
 from rydstate.angular import AngularKetFJ
 from rydstate.rydberg_state.rydberg_base import RydbergState
@@ -39,3 +42,26 @@ class RydbergStateMQDT(RydbergState):
             raise ValueError("All rydberg_kets must have an angular part of type AngularKetFJ.")
 
         super().__init__(species, coefficients, rydberg_kets, nu, energy_au)
+
+    @property
+    def nui(self) -> NDArray:
+        """Return the effective principal quantum numbers nui of the different channels."""
+        return np.array([rydberg_ket.radial.nu for rydberg_ket in self.rydberg_kets])  # type: ignore [attr-defined]
+
+    def calc_exp_qn(self, qn: str) -> float:
+        if qn == "nui":
+            coefficients2 = np.conjugate(self.coefficients) * self.coefficients / self.norm**2
+            return float(np.sum(coefficients2 * self.nui))
+
+        return super().calc_exp_qn(qn)
+
+    def calc_std_qn(self, qn: str) -> float:
+        if qn == "nui":
+            coefficients2 = np.conjugate(self.coefficients) * self.coefficients / self.norm**2
+            exp_q = np.sum(coefficients2 * self.nui)
+            exp_q2 = np.sum(coefficients2 * self.nui * self.nui)
+            if abs(exp_q2 - exp_q**2) < 1e-10:
+                return 0
+            return math.sqrt(exp_q2 - exp_q**2)
+
+        return super().calc_std_qn(qn)

--- a/src/rydstate/rydberg_state/rydberg_sqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_sqdt.py
@@ -255,6 +255,21 @@ class RydbergStateSQDT(RydbergState, Generic[GenericT_AngularKet]):
             return energy
         return energy.to(unit, "spectroscopy").magnitude
 
+    def calc_exp_qn(self, qn: str) -> float:
+        if qn == "n":
+            return self.n
+
+        if qn == "nui":
+            return self.nu
+
+        return super().calc_exp_qn(qn)
+
+    def calc_std_qn(self, qn: str) -> float:
+        if qn == "nui":
+            return 0
+
+        return super().calc_std_qn(qn)
+
 
 class RydbergStateSQDTAlkali(RydbergStateSQDT[AngularKetLS[AllKnown]]):
     """Create an Alkali Rydberg state, including the radial and angular states."""

--- a/src/rydstate/rydberg_state/rydberg_sqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_sqdt.py
@@ -199,6 +199,10 @@ class RydbergStateSQDT(RydbergState, Generic[GenericT_AngularKet]):
                 f"RydbergState initialized with non-normalized coefficients: {self._coefficients}, {self.rydberg_kets}"
             )
 
+        self.f_tot = self.angular.f_tot
+        self.parity = self.angular.parity
+        self.m = self.angular.m
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.species}, n={self.n}, {self.angular!r})"
 

--- a/src/rydstate/rydberg_state/rydberg_sqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_sqdt.py
@@ -8,7 +8,7 @@ from rydstate.angular import NotSet
 from rydstate.angular.angular_ket import AngularKetBase, AngularKetLS
 from rydstate.angular.utils import AllKnown, is_not_set, quantum_numbers_to_angular_ket
 from rydstate.radial import RadialKet
-from rydstate.rydberg_state.rydberg_base import RydbergStateBase
+from rydstate.rydberg_state.rydberg_base import RydbergState
 from rydstate.rydberg_state.rydberg_ket import RydbergKet
 from rydstate.species import get_element_properties, get_sqdt
 from rydstate.species.potential import Potential, get_potential_class
@@ -26,7 +26,7 @@ T_AngularKet = TypeVar("T_AngularKet", bound=AngularKetBase[AllKnown])
 logger = logging.getLogger(__name__)
 
 
-class RydbergStateSQDT(RydbergStateBase, Generic[GenericT_AngularKet]):
+class RydbergStateSQDT(RydbergState, Generic[GenericT_AngularKet]):
     """Create a Rydberg SQDT state, including the radial and angular states."""
 
     species: str

--- a/src/rydstate/rydberg_state/rydberg_sqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_sqdt.py
@@ -226,12 +226,10 @@ class RydbergStateSQDT(RydbergState, Generic[GenericT_AngularKet]):
     def rydberg_kets(self) -> list[RydbergKet]:  # type: ignore [override]
         return [RydbergKet(self.species, self.angular, self.radial)]
 
-    def free_memory(self) -> None:
-        super().free_memory()
-        # For SQDT the radial ket is held by these cached properties of the state itself,
-        # so they have to be dropped as well to actually release the radial wavefunction.
-        self.__dict__.pop("rydberg_kets", None)
+    def _free_memory(self) -> None:
+        super()._free_memory()
         self.__dict__.pop("radial", None)
+        self.__dict__.pop("angular", None)
 
     @overload
     def get_radial_energy(self, unit: None = None) -> PintFloat: ...

--- a/src/rydstate/rydberg_state/rydberg_sqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_sqdt.py
@@ -194,7 +194,10 @@ class RydbergStateSQDT(RydbergStateBase, Generic[GenericT_AngularKet]):
         else:
             self.potential = get_potential_class(species, tag=potential)(self.angular.l_r)
 
-        super().__init__()
+        if abs(self.norm - 1) > 1e-10:
+            raise ValueError(
+                f"RydbergState initialized with non-normalized coefficients: {self._coefficients}, {self.rydberg_kets}"
+            )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.species}, n={self.n}, {self.angular!r})"

--- a/src/rydstate/rydberg_state/rydberg_sqdt.py
+++ b/src/rydstate/rydberg_state/rydberg_sqdt.py
@@ -221,7 +221,7 @@ class RydbergStateSQDT(RydbergStateBase, Generic[GenericT_AngularKet]):
 
     @cached_property
     def rydberg_kets(self) -> list[RydbergKet]:  # type: ignore [override]
-        return [RydbergKet(self.angular, self.radial)]
+        return [RydbergKet(self.species, self.angular, self.radial)]
 
     def free_memory(self) -> None:
         super().free_memory()

--- a/src/rydstate/species/__init__.py
+++ b/src/rydstate/species/__init__.py
@@ -5,7 +5,6 @@ from rydstate.species.mqdt import MQDT, get_mqdt
 from rydstate.species.potential import (
     Potential,
     PotentialCoulomb,
-    PotentialDummy,
     PotentialFei2009,
     PotentialMarinescu1994,
     get_potential_class,
@@ -21,7 +20,6 @@ __all__ = [
     "FModelSQDT",
     "Potential",
     "PotentialCoulomb",
-    "PotentialDummy",
     "PotentialFei2009",
     "PotentialMarinescu1994",
     "cesium",

--- a/src/rydstate/species/potential.py
+++ b/src/rydstate/species/potential.py
@@ -13,7 +13,6 @@ from rydstate.species.element_properties import get_element_properties
 from rydstate.species.utils import get_all_subclasses
 
 if TYPE_CHECKING:
-    from rydstate.angular.utils import Unknown
     from rydstate.units import NDArray
 
 XType = TypeVar("XType", "NDArray", float)
@@ -31,8 +30,6 @@ class Potential(ABC, metaclass=CachedABCMeta):
     """The tag for these potential parameters."""
     is_default: ClassVar[bool] = False
     """Whether this potential is the default potential for the species."""
-    is_dummy: ClassVar[bool] = False
-    """Whether this potential is a dummy potential (with unknown l_r)."""
 
     def __init__(self, l_r: int) -> None:
         r"""Initialize the potential.
@@ -43,11 +40,7 @@ class Potential(ABC, metaclass=CachedABCMeta):
         """
         self.element_properties = get_element_properties(self.species)
 
-        if is_unknown(l_r):
-            raise ValueError(
-                f"l_r cannot be unknown for {self.__class__.__name__}, use a dummy potential if l_r is unknown"
-            )
-        if not ((isinstance(l_r, int) or l_r.is_integer()) and l_r >= 0):
+        if is_unknown(l_r) or not ((isinstance(l_r, int) or l_r.is_integer()) and l_r >= 0):
             raise ValueError(f"l_r must be an integer, and larger or equal 0, but {l_r=}")
         self.l_r = int(l_r)
 
@@ -355,30 +348,6 @@ class PotentialFei2009(Potential):
         with np.errstate(over="ignore"):
             denom: XType = 1 - alpha + alpha * np.exp(beta * x**delta + gamma * x ** (2.0 * delta))
             return -1 / x - (self.element_properties.Z - 1) / (x * denom)
-
-
-class PotentialDummy(Potential):
-    """Dummy potential, which can be used when the potential is unknown."""
-
-    tag = "dummy"
-    is_dummy = True
-    l_r: int | Unknown  # type: ignore [assignment]
-
-    def __init__(self, species: str, l_r: int | Unknown) -> None:
-        r"""Initialize the dummy potential.
-
-        Args:
-            species: The species for which to initialize the dummy potential.
-            l_r: Orbital angular momentum of the Rydberg electron.
-
-        """
-        self.species = species  # type: ignore [misc]
-        self.element_properties = get_element_properties(self.species)
-
-        self.l_r = l_r
-
-    def calc_model_potential(self, x: XType) -> XType:  # noqa: ARG002
-        raise RuntimeError(f"The model potential is unknown for {self.__class__.__name__}, so it cannot be calculated.")
 
 
 def get_potential_class(species: str, tag: str | None = None) -> type[Potential]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from rydstate.angular.utils import CouplingScheme
+
+COUPLING_SCHEMES: tuple[CouplingScheme, ...] = ("LS", "JJ", "FJ")
+
+
+@pytest.fixture(params=COUPLING_SCHEMES)
+def coupling_scheme(request: pytest.FixtureRequest) -> CouplingScheme:
+    """Parametrized fixture yielding each of the three angular coupling schemes ("LS", "JJ", "FJ").
+
+    Any test that takes ``coupling_scheme`` as an argument is automatically run once per scheme.
+    """
+    return request.param  # type: ignore[no-any-return]

--- a/tests/test_angular_matrix_elements.py
+++ b/tests/test_angular_matrix_elements.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, get_args
 import numpy as np
 import pytest
 from rydstate.angular import AngularKetFJ, AngularKetJJ, AngularKetLS
-from rydstate.angular.utils import AngularMomentumQuantumNumbers
+from rydstate.angular.utils import AngularMomentumQuantumNumbers, Unknown
 
 if TYPE_CHECKING:
     from rydstate.angular.angular_ket import AngularKetBase
@@ -62,6 +62,37 @@ def test_overlap_different_coupling_schemes(ket1: AngularKetBase[AllKnown], ket2
         assert np.isclose(ov, ket1.to_state(scheme).calc_reduced_overlap(ket2))
         assert np.isclose(1, ket1.to_state(scheme).calc_reduced_overlap(ket1))
         assert np.isclose(1, ket2.to_state(scheme).calc_reduced_overlap(ket2))
+
+
+def test_identical_unknown_kets_have_unit_overlap() -> None:
+    ket1 = AngularKetLS(
+        i_c=0,
+        s_c=0,
+        l_c=0,
+        s_r=0.5,
+        l_r=Unknown,
+        s_tot=0.5,
+        l_tot=Unknown,
+        j_tot=Unknown,
+        f_tot=0.5,
+        parity=1,
+        allow_unknown=True,
+    )
+    ket2 = AngularKetLS(
+        i_c=0,
+        s_c=0,
+        l_c=0,
+        s_r=0.5,
+        l_r=Unknown,
+        s_tot=0.5,
+        l_tot=Unknown,
+        j_tot=Unknown,
+        f_tot=0.5,
+        parity=1,
+        allow_unknown=True,
+    )
+    assert ket1.calc_reduced_overlap(ket2) == 1.0
+    assert ket2.calc_reduced_overlap(ket1) == 1.0
 
 
 @pytest.mark.parametrize("ket", TEST_KETS)

--- a/tests/test_angular_matrix_elements.py
+++ b/tests/test_angular_matrix_elements.py
@@ -40,28 +40,25 @@ TEST_KETS = [
 
 
 @pytest.mark.parametrize("ket", TEST_KETS)
-def test_exp_q_different_coupling_schemes(ket: AngularKetBase[AllKnown]) -> None:
+def test_exp_q_different_coupling_schemes(ket: AngularKetBase[AllKnown], coupling_scheme: CouplingScheme) -> None:
+    """Expectation values and standard deviations of every quantum number are scheme-independent."""
     all_qs: tuple[AngularMomentumQuantumNumbers, ...] = get_args(AngularMomentumQuantumNumbers)
     for q in all_qs:
-        exp_q = ket.to_state("LS").calc_exp_qn(q)
-        assert np.isclose(exp_q, ket.to_state("JJ").calc_exp_qn(q))
-        assert np.isclose(exp_q, ket.to_state("FJ").calc_exp_qn(q))
-
-        std_q = ket.to_state("LS").calc_std_qn(q)
-        assert np.isclose(std_q, ket.to_state("JJ").calc_std_qn(q))
-        assert np.isclose(std_q, ket.to_state("FJ").calc_std_qn(q))
+        # the LS scheme serves as the fixed reference the other schemes are compared against
+        assert np.isclose(ket.to_state("LS").calc_exp_qn(q), ket.to_state(coupling_scheme).calc_exp_qn(q))
+        assert np.isclose(ket.to_state("LS").calc_std_qn(q), ket.to_state(coupling_scheme).calc_std_qn(q))
 
 
 @pytest.mark.parametrize(("ket1", "ket2"), TEST_KET_PAIRS)
-def test_overlap_different_coupling_schemes(ket1: AngularKetBase[AllKnown], ket2: AngularKetBase[AllKnown]) -> None:
+def test_overlap_different_coupling_schemes(
+    ket1: AngularKetBase[AllKnown], ket2: AngularKetBase[AllKnown], coupling_scheme: CouplingScheme
+) -> None:
     ov = ket1.calc_reduced_overlap(ket2)
 
-    coupling_schemes: list[CouplingScheme] = ["LS", "JJ", "FJ"]
-    for scheme in coupling_schemes:
-        assert np.isclose(ov, ket1.to_state().calc_reduced_overlap(ket2.to_state(scheme)))
-        assert np.isclose(ov, ket1.to_state(scheme).calc_reduced_overlap(ket2))
-        assert np.isclose(1, ket1.to_state(scheme).calc_reduced_overlap(ket1))
-        assert np.isclose(1, ket2.to_state(scheme).calc_reduced_overlap(ket2))
+    assert np.isclose(ov, ket1.to_state().calc_reduced_overlap(ket2.to_state(coupling_scheme)))
+    assert np.isclose(ov, ket1.to_state(coupling_scheme).calc_reduced_overlap(ket2))
+    assert np.isclose(1, ket1.to_state(coupling_scheme).calc_reduced_overlap(ket1))
+    assert np.isclose(1, ket2.to_state(coupling_scheme).calc_reduced_overlap(ket2))
 
 
 def test_identical_unknown_kets_have_unit_overlap() -> None:
@@ -96,20 +93,18 @@ def test_identical_unknown_kets_have_unit_overlap() -> None:
 
 
 @pytest.mark.parametrize("ket", TEST_KETS)
-def test_reduced_identity(ket: AngularKetBase[AllKnown]) -> None:
+def test_reduced_identity(ket: AngularKetBase[AllKnown], coupling_scheme: CouplingScheme) -> None:
     reduced_identity = np.sqrt(2 * ket.f_tot + 1)
 
     op: AngularMomentumQuantumNumbers
-    coupling_schemes: list[CouplingScheme] = ["LS", "JJ", "FJ"]
-    for scheme in coupling_schemes:
-        state = ket.to_state(scheme)
-        for op in state.kets[0].quantum_number_names:
-            assert np.isclose(reduced_identity, state.calc_reduced_matrix_element(state, "identity_" + op, kappa=0))  # type: ignore [arg-type]
+    state = ket.to_state(coupling_scheme)
+    for op in state.kets[0].quantum_number_names:
+        assert np.isclose(reduced_identity, state.calc_reduced_matrix_element(state, "identity_" + op, kappa=0))  # type: ignore [arg-type]
 
 
 @pytest.mark.parametrize(("ket1", "ket2"), TEST_KET_PAIRS)
 def test_matrix_elements_in_different_coupling_schemes(
-    ket1: AngularKetBase[AllKnown], ket2: AngularKetBase[AllKnown]
+    ket1: AngularKetBase[AllKnown], ket2: AngularKetBase[AllKnown], coupling_scheme: CouplingScheme
 ) -> None:
     example_list: list[tuple[AngularOperatorType, int]] = [
         ("spherical", 0),
@@ -122,14 +117,12 @@ def test_matrix_elements_in_different_coupling_schemes(
         ("f_tot", 1),
         ("j_tot", 1),
     ]
-    coupling_schemes: list[CouplingScheme] = ["LS", "JJ", "FJ"]
 
-    for scheme in coupling_schemes:
-        for operator, kappa in example_list:
-            msg = f"{operator=}, {kappa=}, {ket1=}, {ket2=}, {scheme=}"
-            val = ket1.calc_reduced_matrix_element(ket2, operator, kappa)
+    for operator, kappa in example_list:
+        msg = f"{operator=}, {kappa=}, {ket1=}, {ket2=}, {coupling_scheme=}"
+        val = ket1.calc_reduced_matrix_element(ket2, operator, kappa)
 
-            assert np.isclose(
-                val, ket1.to_state().calc_reduced_matrix_element(ket2.to_state(scheme), operator, kappa)
-            ), msg
-            assert np.isclose(val, ket1.to_state(scheme).calc_reduced_matrix_element(ket2, operator, kappa)), msg
+        assert np.isclose(
+            val, ket1.to_state().calc_reduced_matrix_element(ket2.to_state(coupling_scheme), operator, kappa)
+        ), msg
+        assert np.isclose(val, ket1.to_state(coupling_scheme).calc_reduced_matrix_element(ket2, operator, kappa)), msg

--- a/tests/test_basis_mqdt.py
+++ b/tests/test_basis_mqdt.py
@@ -22,7 +22,7 @@ def test_mqdt_basis_f_tot_filter() -> None:
     basis = BasisMQDT("Sr88", nu=(25, 30), f_tot=(0, 0))
     assert len(basis) > 0
     for state in basis.states:
-        assert abs(state.angular.calc_exp_qn("f_tot") - 0.0) < 1e-10
+        assert abs(state.calc_exp_qn("f_tot") - 0.0) < 1e-10
 
 
 def test_mqdt_basis_m_range() -> None:

--- a/tests/test_free_memory.py
+++ b/tests/test_free_memory.py
@@ -12,10 +12,10 @@ from rydstate.basis import BasisMQDT
 from rydstate.radial import RadialDummy, RadialKet
 
 if TYPE_CHECKING:
-    from rydstate.radial.radial_base import RadialBase
+    from rydstate.radial.radial_base import Radial
 
 
-def _cache_key(radial: RadialBase) -> tuple[tuple[str, object], ...]:
+def _cache_key(radial: Radial) -> tuple[tuple[str, object], ...]:
     """Return the key under which the given radial ket is stored in RadialKet._instances."""
     with contextlib.suppress(StopIteration):
         return next(key for key, value in RadialKet._instances.items() if value is radial)
@@ -30,7 +30,7 @@ def test_free_memory_releases_radial_kets_sqdt() -> None:
     state = RydbergStateSQDTAlkali("Rb", n=50, l=0, j=0.5)
 
     # access radial and angular kets to ensure they are created (and the radial ket is cached)
-    radial_refs: list[weakref.ref[RadialBase]] = []
+    radial_refs: list[weakref.ref[Radial]] = []
     cache_keys = []
     for ket in state.rydberg_kets:
         radial, _angular = ket.radial, ket.angular
@@ -58,7 +58,7 @@ def test_free_memory_releases_radial_kets_mqdt() -> None:
     assert len(state.rydberg_kets) > 1
 
     # access radial and angular kets to ensure they are created (and the radial kets are cached)
-    radial_refs: list[weakref.ref[RadialBase]] = []
+    radial_refs: list[weakref.ref[Radial]] = []
     cache_keys = []
     for ket in state.rydberg_kets:
         radial, _angular = ket.radial, ket.angular

--- a/tests/test_free_memory.py
+++ b/tests/test_free_memory.py
@@ -2,17 +2,26 @@
 
 from __future__ import annotations
 
+import contextlib
 import gc
 import weakref
+from typing import TYPE_CHECKING
 
 from rydstate import RydbergStateSQDTAlkali
 from rydstate.basis import BasisMQDT
-from rydstate.radial import RadialKet
+from rydstate.radial import RadialDummy, RadialKet
+
+if TYPE_CHECKING:
+    from rydstate.radial.radial_base import RadialBase
 
 
-def _cache_key(radial: RadialKet) -> tuple[tuple[str, object], ...]:
+def _cache_key(radial: RadialBase) -> tuple[tuple[str, object], ...]:
     """Return the key under which the given radial ket is stored in RadialKet._instances."""
-    return next(key for key, value in RadialKet._instances.items() if value is radial)
+    with contextlib.suppress(StopIteration):
+        return next(key for key, value in RadialKet._instances.items() if value is radial)
+    with contextlib.suppress(StopIteration):
+        return next(key for key, value in RadialDummy._instances.items() if value is radial)
+    raise ValueError("Radial ket is not cached in RadialKet._instances or RadialDummy._instances")
 
 
 def test_free_memory_releases_radial_kets_sqdt() -> None:
@@ -21,7 +30,7 @@ def test_free_memory_releases_radial_kets_sqdt() -> None:
     state = RydbergStateSQDTAlkali("Rb", n=50, l=0, j=0.5)
 
     # access radial and angular kets to ensure they are created (and the radial ket is cached)
-    radial_refs: list[weakref.ref[RadialKet]] = []
+    radial_refs: list[weakref.ref[RadialBase]] = []
     cache_keys = []
     for ket in state.rydberg_kets:
         radial, _angular = ket.radial, ket.angular
@@ -49,7 +58,7 @@ def test_free_memory_releases_radial_kets_mqdt() -> None:
     assert len(state.rydberg_kets) > 1
 
     # access radial and angular kets to ensure they are created (and the radial kets are cached)
-    radial_refs: list[weakref.ref[RadialKet]] = []
+    radial_refs: list[weakref.ref[RadialBase]] = []
     cache_keys = []
     for ket in state.rydberg_kets:
         radial, _angular = ket.radial, ket.angular
@@ -58,7 +67,7 @@ def test_free_memory_releases_radial_kets_mqdt() -> None:
     del radial, _angular, ket
 
     assert all(ref() is not None for ref in radial_refs)
-    assert all(key in RadialKet._instances for key in cache_keys)
+    assert all(key in RadialKet._instances or key in RadialDummy._instances for key in cache_keys)
 
     # drop the basis so sibling states do not keep the (potentially shared) radial kets alive
     del basis
@@ -67,4 +76,4 @@ def test_free_memory_releases_radial_kets_mqdt() -> None:
 
     # the radial kets are no longer referenced and have been evicted from the cache
     assert all(ref() is None for ref in radial_refs)
-    assert all(key not in RadialKet._instances for key in cache_keys)
+    assert all(key not in RadialKet._instances and key not in RadialDummy._instances for key in cache_keys)

--- a/tests/test_free_memory.py
+++ b/tests/test_free_memory.py
@@ -41,7 +41,7 @@ def test_free_memory_releases_radial_kets_sqdt() -> None:
     assert all(ref() is not None for ref in radial_refs)
     assert all(key in RadialKet._instances for key in cache_keys)
 
-    state.free_memory()
+    state._free_memory()
     gc.collect()
 
     # the radial kets are no longer referenced and have been evicted from the cache
@@ -71,7 +71,7 @@ def test_free_memory_releases_radial_kets_mqdt() -> None:
 
     # drop the basis so sibling states do not keep the (potentially shared) radial kets alive
     del basis
-    state.free_memory()
+    state._free_memory()
     gc.collect()
 
     # the radial kets are no longer referenced and have been evicted from the cache

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -1,5 +1,4 @@
-from rydstate.angular.utils import Unknown
-from rydstate.species.potential import PotentialDummy, get_potential_class
+from rydstate.species.potential import get_potential_class
 
 
 def test_potential_is_reused_for_same_class_and_l_r() -> None:
@@ -19,10 +18,3 @@ def test_potential_cache_distinguishes_class_and_l_r() -> None:
 
     assert hydrogen_potential_class(1) is not potential
     assert rubidium_potential_class(0) is not potential
-
-
-def test_dummy_potential_is_reused_for_same_species_and_l_r() -> None:
-    potential = PotentialDummy("Sr87", Unknown)
-
-    assert PotentialDummy(species="Sr87", l_r=Unknown) is potential
-    assert PotentialDummy("Sr88", Unknown) is not potential

--- a/tests/test_radial_base.py
+++ b/tests/test_radial_base.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from rydstate.radial import RadialBase, RadialDummy
+
+
+def _make_radial(*, dz: float = 0.01, zmax: float = 6.0, center: float = 3.0, width: float = 0.5) -> RadialBase:
+    """Build a normalized gaussian-shaped radial wavefunction on the standard grid [0, dz, 2*dz, ...]."""
+    z = np.arange(0, zmax + dz / 2, dz)
+    w = np.exp(-0.5 * ((z - center) / width) ** 2)
+    radial = RadialBase(z, w)
+    return radial / radial.norm
+
+
+# --------------------------------------------------------------------------------------
+# grid / wavefunction properties
+# --------------------------------------------------------------------------------------
+
+
+def test_grid_properties() -> None:
+    dz = 0.1
+    z = np.arange(0, 2 + dz / 2, dz)
+    radial = RadialBase(z, np.ones_like(z))
+
+    assert radial.steps == len(z)
+    assert np.isclose(radial.dz, dz)
+    assert np.allclose(radial.x_list, z**2)
+    assert np.allclose(radial.u_list, np.sqrt(z) * radial.w_list)
+
+
+def test_norm_matches_manual_formula() -> None:
+    dz = 0.1
+    z = np.arange(0, 3 + dz / 2, dz)
+    w = np.exp(-0.5 * (z - 1.5) ** 2)
+    radial = RadialBase(z, w)
+
+    expected = np.sqrt(2 * np.sum(w * w * z * z) * dz)
+    assert np.isclose(radial.norm, expected)
+
+
+def test_normalization_yields_unit_norm() -> None:
+    assert np.isclose(_make_radial().norm, 1.0)
+
+
+# --------------------------------------------------------------------------------------
+# arithmetic: addition, subtraction and negation
+# --------------------------------------------------------------------------------------
+
+
+def test_add_on_shared_grid() -> None:
+    dz = 0.1
+    z = np.arange(0, 1 + dz / 2, dz)
+    a = RadialBase(z, np.ones_like(z))
+    b = RadialBase(z, 2 * np.ones_like(z))
+
+    result = a + b
+    assert np.allclose(result.z_list, z)
+    assert np.allclose(result.w_list, 3.0)
+
+
+def test_add_zero_pads_onto_common_grid() -> None:
+    """Two states on offset (but lattice-aligned) grids are zero-padded onto a common grid."""
+    dz = 0.1
+    za = np.arange(0, 1 + dz / 2, dz)  # covers [0.0, 1.0]
+    zb = np.arange(0.5, 1.5 + dz / 2, dz)  # covers [0.5, 1.5]
+    a = RadialBase(za, np.ones_like(za))
+    b = RadialBase(zb, np.ones_like(zb))
+
+    result = a + b
+    # common grid spans the union of both grids
+    assert np.isclose(result.z_list[0], 0.0)
+    assert np.isclose(result.z_list[-1], 1.5)
+
+    # where only `a` lives (z < 0.5) -> 1, in the overlap (0.5 <= z <= 1.0) -> 2, only `b` (z > 1.0) -> 1
+    for z, w in zip(result.z_list, result.w_list, strict=True):
+        if z < 0.5 - 1e-9:
+            assert np.isclose(w, 1.0)
+        elif z <= 1.0 + 1e-9:
+            assert np.isclose(w, 2.0)
+        else:
+            assert np.isclose(w, 1.0)
+
+
+def test_add_is_commutative() -> None:
+    dz = 0.1
+    za = np.arange(0, 1 + dz / 2, dz)
+    zb = np.arange(0.5, 1.5 + dz / 2, dz)
+    a = RadialBase(za, np.ones_like(za))
+    b = RadialBase(zb, 2 * np.ones_like(zb))
+
+    assert np.allclose((a + b).w_list, (b + a).w_list)
+
+
+def test_neg_and_sub() -> None:
+    dz = 0.1
+    z = np.arange(0, 1 + dz / 2, dz)
+    a = RadialBase(z, np.full_like(z, 3.0))
+    b = RadialBase(z, np.full_like(z, 1.0))
+
+    assert np.allclose((-a).w_list, -3.0)
+    assert np.allclose((a - b).w_list, 2.0)
+    # subtraction equals addition of the negation
+    assert np.allclose((a - b).w_list, (a + (-b)).w_list)
+
+
+def test_add_returns_not_implemented_for_non_radial() -> None:
+    dz = 0.1
+    z = np.arange(0, 1 + dz / 2, dz)
+    a = RadialBase(z, np.ones_like(z))
+    with pytest.raises(TypeError):
+        _ = a + 5  # type: ignore[operator]
+
+
+# --------------------------------------------------------------------------------------
+# arithmetic: scalar multiplication and division
+# --------------------------------------------------------------------------------------
+
+
+def test_scalar_multiplication() -> None:
+    dz = 0.1
+    z = np.arange(0, 1 + dz / 2, dz)
+    a = RadialBase(z, np.full_like(z, 2.0))
+
+    assert np.allclose((a * 3).w_list, 6.0)
+    assert np.allclose((3 * a).w_list, 6.0)  # __rmul__
+    assert np.allclose((a / 2).w_list, 1.0)  # __truediv__
+    # grid is untouched by scalar operations
+    assert np.allclose((a * 3).z_list, z)
+
+
+def test_mul_returns_not_implemented_for_non_number() -> None:
+    dz = 0.1
+    z = np.arange(0, 1 + dz / 2, dz)
+    a = RadialBase(z, np.ones_like(z))
+    with pytest.raises(TypeError):
+        _ = a * "x"  # type: ignore[operator]
+
+
+def test_norm_scales_linearly_with_scalar() -> None:
+    a = _make_radial()
+    assert np.isclose((3 * a).norm, 3 * a.norm)
+    assert np.isclose((a / 4).norm, a.norm / 4)
+
+
+# --------------------------------------------------------------------------------------
+# _align error handling
+# --------------------------------------------------------------------------------------
+
+
+def test_align_rejects_different_dz() -> None:
+    a = RadialBase(np.arange(0, 1 + 0.05, 0.1), np.ones(11))
+    b = RadialBase(np.arange(0, 1 + 0.1, 0.2), np.ones(6))
+    with pytest.raises(ValueError, match="different dz"):
+        _ = a + b
+
+
+def test_rejects_grids_off_the_global_lattice() -> None:
+    z = np.arange(0.03, 1 + 0.03, 0.1)
+    with pytest.raises(ValueError, match="z_list must start at an integer multiple of dz"):
+        RadialBase(z, np.ones_like(z))
+
+
+# --------------------------------------------------------------------------------------
+# calc_overlap / calc_matrix_element
+# --------------------------------------------------------------------------------------
+
+
+def test_self_overlap_of_normalized_state_is_one() -> None:
+    a = _make_radial()
+    assert np.isclose(a.calc_overlap(a), 1.0)
+
+
+def test_overlap_is_symmetric() -> None:
+    a = _make_radial(center=2.5)
+    b = _make_radial(center=3.5)
+    assert np.isclose(a.calc_overlap(b), b.calc_overlap(a))
+
+
+def test_overlap_is_linear_in_scalar() -> None:
+    a = _make_radial(center=2.5)
+    b = _make_radial(center=3.5)
+    assert np.isclose(a.calc_overlap(2 * b), 2 * a.calc_overlap(b))
+
+
+def test_calc_matrix_element_k_radial_zero_equals_overlap() -> None:
+    a = _make_radial(center=2.5)
+    b = _make_radial(center=3.5)
+    assert np.isclose(a.calc_matrix_element(b, k_radial=0, unit="a.u."), a.calc_overlap(b))
+
+
+def test_calc_matrix_element_unit_handling() -> None:
+    a = _make_radial(center=2.5)
+    b = _make_radial(center=3.5)
+
+    me_pint = a.calc_matrix_element(b, k_radial=1)  # default -> pint quantity in a0
+    me_au = a.calc_matrix_element(b, k_radial=1, unit="a.u.")  # raw float in atomic units
+
+    assert isinstance(me_au, float)
+    # the pint quantity carries the atomic-unit magnitude in units of a0
+    assert np.isclose(me_pint.magnitude, me_au)
+    # explicitly requesting a unit returns the converted magnitude of the same quantity
+    me_um = a.calc_matrix_element(b, k_radial=1, unit="micrometer")
+    assert np.isclose(me_um, me_pint.to("micrometer").magnitude)
+
+
+# --------------------------------------------------------------------------------------
+# RadialDummy
+# --------------------------------------------------------------------------------------
+
+
+def test_radial_dummy_norm_is_abs_coefficient() -> None:
+    assert RadialDummy(2.0, nu=50).norm == 2.0
+    assert RadialDummy(-3.0, nu=50).norm == 3.0
+
+
+def test_radial_dummy_multiplication_returns_dummy() -> None:
+    d = RadialDummy(2.0, nu=50)
+
+    scaled = d * 3
+    assert isinstance(scaled, RadialDummy)
+    assert scaled.norm == 6.0
+    assert scaled.nu == 50
+
+    # __rmul__, __truediv__ and __neg__ all route through RadialDummy.__mul__
+    assert isinstance(3 * d, RadialDummy)
+    assert isinstance(d / 2, RadialDummy)
+    assert isinstance(-d, RadialDummy)
+    assert (3 * d).norm == 6.0
+    assert (d / 2).norm == 1.0
+    assert (-d).norm == 2.0
+
+
+def test_radial_dummy_mul_returns_not_implemented_for_non_number() -> None:
+    d = RadialDummy(2.0, nu=50)
+    with pytest.raises(TypeError):
+        _ = d * "x"  # type: ignore[operator]

--- a/tests/test_radial_base.py
+++ b/tests/test_radial_base.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from rydstate.radial import RadialBase, RadialDummy
+from rydstate.radial import Radial, RadialDummy
 
 
-def _make_radial(*, dz: float = 0.01, zmax: float = 6.0, center: float = 3.0, width: float = 0.5) -> RadialBase:
+def _make_radial(*, dz: float = 0.01, zmax: float = 6.0, center: float = 3.0, width: float = 0.5) -> Radial:
     """Build a normalized gaussian-shaped radial wavefunction on the standard grid [0, dz, 2*dz, ...]."""
     z = np.arange(0, zmax + dz / 2, dz)
     w = np.exp(-0.5 * ((z - center) / width) ** 2)
-    radial = RadialBase(z, w)
+    radial = Radial(z, w)
     return radial / radial.norm
 
 
@@ -21,7 +21,7 @@ def _make_radial(*, dz: float = 0.01, zmax: float = 6.0, center: float = 3.0, wi
 def test_grid_properties() -> None:
     dz = 0.1
     z = np.arange(0, 2 + dz / 2, dz)
-    radial = RadialBase(z, np.ones_like(z))
+    radial = Radial(z, np.ones_like(z))
 
     assert radial.steps == len(z)
     assert np.isclose(radial.dz, dz)
@@ -33,7 +33,7 @@ def test_norm_matches_manual_formula() -> None:
     dz = 0.1
     z = np.arange(0, 3 + dz / 2, dz)
     w = np.exp(-0.5 * (z - 1.5) ** 2)
-    radial = RadialBase(z, w)
+    radial = Radial(z, w)
 
     expected = np.sqrt(2 * np.sum(w * w * z * z) * dz)
     assert np.isclose(radial.norm, expected)
@@ -51,8 +51,8 @@ def test_normalization_yields_unit_norm() -> None:
 def test_add_on_shared_grid() -> None:
     dz = 0.1
     z = np.arange(0, 1 + dz / 2, dz)
-    a = RadialBase(z, np.ones_like(z))
-    b = RadialBase(z, 2 * np.ones_like(z))
+    a = Radial(z, np.ones_like(z))
+    b = Radial(z, 2 * np.ones_like(z))
 
     result = a + b
     assert np.allclose(result.z_list, z)
@@ -64,8 +64,8 @@ def test_add_zero_pads_onto_common_grid() -> None:
     dz = 0.1
     za = np.arange(0, 1 + dz / 2, dz)  # covers [0.0, 1.0]
     zb = np.arange(0.5, 1.5 + dz / 2, dz)  # covers [0.5, 1.5]
-    a = RadialBase(za, np.ones_like(za))
-    b = RadialBase(zb, np.ones_like(zb))
+    a = Radial(za, np.ones_like(za))
+    b = Radial(zb, np.ones_like(zb))
 
     result = a + b
     # common grid spans the union of both grids
@@ -86,8 +86,8 @@ def test_add_is_commutative() -> None:
     dz = 0.1
     za = np.arange(0, 1 + dz / 2, dz)
     zb = np.arange(0.5, 1.5 + dz / 2, dz)
-    a = RadialBase(za, np.ones_like(za))
-    b = RadialBase(zb, 2 * np.ones_like(zb))
+    a = Radial(za, np.ones_like(za))
+    b = Radial(zb, 2 * np.ones_like(zb))
 
     assert np.allclose((a + b).w_list, (b + a).w_list)
 
@@ -95,8 +95,8 @@ def test_add_is_commutative() -> None:
 def test_neg_and_sub() -> None:
     dz = 0.1
     z = np.arange(0, 1 + dz / 2, dz)
-    a = RadialBase(z, np.full_like(z, 3.0))
-    b = RadialBase(z, np.full_like(z, 1.0))
+    a = Radial(z, np.full_like(z, 3.0))
+    b = Radial(z, np.full_like(z, 1.0))
 
     assert np.allclose((-a).w_list, -3.0)
     assert np.allclose((a - b).w_list, 2.0)
@@ -107,7 +107,7 @@ def test_neg_and_sub() -> None:
 def test_add_returns_not_implemented_for_non_radial() -> None:
     dz = 0.1
     z = np.arange(0, 1 + dz / 2, dz)
-    a = RadialBase(z, np.ones_like(z))
+    a = Radial(z, np.ones_like(z))
     with pytest.raises(TypeError):
         _ = a + 5  # type: ignore[operator]
 
@@ -120,7 +120,7 @@ def test_add_returns_not_implemented_for_non_radial() -> None:
 def test_scalar_multiplication() -> None:
     dz = 0.1
     z = np.arange(0, 1 + dz / 2, dz)
-    a = RadialBase(z, np.full_like(z, 2.0))
+    a = Radial(z, np.full_like(z, 2.0))
 
     assert np.allclose((a * 3).w_list, 6.0)
     assert np.allclose((3 * a).w_list, 6.0)  # __rmul__
@@ -132,7 +132,7 @@ def test_scalar_multiplication() -> None:
 def test_mul_returns_not_implemented_for_non_number() -> None:
     dz = 0.1
     z = np.arange(0, 1 + dz / 2, dz)
-    a = RadialBase(z, np.ones_like(z))
+    a = Radial(z, np.ones_like(z))
     with pytest.raises(TypeError):
         _ = a * "x"  # type: ignore[operator]
 
@@ -149,8 +149,8 @@ def test_norm_scales_linearly_with_scalar() -> None:
 
 
 def test_align_rejects_different_dz() -> None:
-    a = RadialBase(np.arange(0, 1 + 0.05, 0.1), np.ones(11))
-    b = RadialBase(np.arange(0, 1 + 0.1, 0.2), np.ones(6))
+    a = Radial(np.arange(0, 1 + 0.05, 0.1), np.ones(11))
+    b = Radial(np.arange(0, 1 + 0.1, 0.2), np.ones(6))
     with pytest.raises(ValueError, match="different dz"):
         _ = a + b
 
@@ -158,7 +158,7 @@ def test_align_rejects_different_dz() -> None:
 def test_rejects_grids_off_the_global_lattice() -> None:
     z = np.arange(0.03, 1 + 0.03, 0.1)
     with pytest.raises(ValueError, match="z_list must start at an integer multiple of dz"):
-        RadialBase(z, np.ones_like(z))
+        Radial(z, np.ones_like(z))
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_rydberg_state_mqdt.py
+++ b/tests/test_rydberg_state_mqdt.py
@@ -20,12 +20,11 @@ def basis() -> BasisMQDT:
 def _find_state(basis: BasisMQDT, *, l_r: int, f_tot: float, s_tot: float | None = None) -> RydbergStateMQDT:
     """Return the first MQDT state matching the given (expectation value) quantum numbers."""
     for state in basis.states:
-        angular = state.angular
-        if abs(angular.calc_exp_qn("l_r") - l_r) > 1e-6:
+        if abs(state.calc_exp_qn("l_r") - l_r) > 1e-6:
             continue
-        if abs(angular.calc_exp_qn("f_tot") - f_tot) > 1e-6:
+        if abs(state.calc_exp_qn("f_tot") - f_tot) > 1e-6:
             continue
-        if s_tot is not None and abs(angular.calc_exp_qn("s_tot") - s_tot) > 1e-2:
+        if s_tot is not None and abs(state.calc_exp_qn("s_tot") - s_tot) > 1e-2:
             continue
         return state
     raise AssertionError(f"No MQDT state found for l_r={l_r}, f_tot={f_tot}, s_tot={s_tot}")
@@ -34,31 +33,28 @@ def _find_state(basis: BasisMQDT, *, l_r: int, f_tot: float, s_tot: float | None
 def test_quantum_number_expectation_values(basis: BasisMQDT) -> None:
     """f_tot is a good quantum number; l_r/s_tot/j_tot have sensible expectation values."""
     for state in basis.states:
-        angular = state.angular
-
         # f_tot is conserved within an MQDT model, so it is exact (zero spread).
-        f_tot = angular.calc_exp_qn("f_tot")
-        assert angular.calc_std_qn("f_tot") == 0
+        f_tot = state.calc_exp_qn("f_tot")
+        assert state.calc_std_qn("f_tot") == 0
         # f_tot must be a (half-)integer >= 0.
         assert f_tot >= 0
         assert abs(2 * f_tot - round(2 * f_tot)) < 1e-12
 
         # l_r expectation value must lie within the range spanned by the channels.
         l_r_channels = [ket.angular.l_r for ket in state.rydberg_kets]
-        l_r_exp = angular.calc_exp_qn("l_r")
+        l_r_exp = state.calc_exp_qn("l_r")
         assert min(l_r_channels) <= l_r_exp <= max(l_r_channels)
 
         # s_tot expectation value is between 0 and 1 (singlet/triplet mixing).
-        s_tot_exp = angular.calc_exp_qn("s_tot")
+        s_tot_exp = state.calc_exp_qn("s_tot")
         assert 0 <= s_tot_exp <= 1
 
 
 def test_single_channel_state_has_sharp_quantum_numbers(basis: BasisMQDT) -> None:
     """A single-channel MQDT state behaves like a pure SQDT-like state with sharp qn."""
     state = next(s for s in basis.states if len(s.rydberg_kets) == 1)
-    angular = state.angular
     for qn in ("l_r", "j_r", "f_c", "f_tot", "s_tot", "j_tot"):
-        assert angular.calc_std_qn(qn) < 1e-12
+        assert state.calc_std_qn(qn) < 1e-12
 
 
 def test_self_overlap_is_one(basis: BasisMQDT) -> None:

--- a/tests/test_to_coupling_scheme.py
+++ b/tests/test_to_coupling_scheme.py
@@ -109,7 +109,7 @@ def test_calc_exp_qn_uses_conversion_for_foreign_quantum_number(ls_state: Rydber
     assert "j_r" not in ls_state.rydberg_kets[0].angular.quantum_number_names
 
     exp_via_calc = ls_state.calc_exp_qn("j_r")
-    exp_via_manual_conversion = ls_state.to_coupling_scheme("JJ").angular_state.calc_exp_qn("j_r")
+    exp_via_manual_conversion = ls_state.to_coupling_scheme("JJ").calc_exp_qn("j_r")
     assert np.isclose(exp_via_calc, exp_via_manual_conversion)
 
 

--- a/tests/test_to_coupling_scheme.py
+++ b/tests/test_to_coupling_scheme.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pytest
+from rydstate import BasisMQDT, RydbergStateSQDT
+
+if TYPE_CHECKING:
+    from rydstate.angular.utils import CouplingScheme
+
+
+@pytest.fixture(scope="module")
+def ls_state() -> RydbergStateSQDT[Any]:
+    """Return a triplet-P (3P1) SQDT state of Sr88, given in the LS coupling scheme."""
+    return RydbergStateSQDT("Sr88", n=60, l_r=1, s_tot=1, l_tot=1, j_tot=1, f_tot=1)
+
+
+@pytest.fixture(scope="module")
+def mqdt_basis() -> BasisMQDT:
+    return BasisMQDT("Sr88", nu=(28.0, 30.0))
+
+
+# --------------------------------------------------------------------------------------
+# basic invariants of the conversion
+# --------------------------------------------------------------------------------------
+
+
+def test_converting_to_same_scheme_is_identity(ls_state: RydbergStateSQDT[Any]) -> None:
+    converted = ls_state.to_coupling_scheme("LS")
+
+    assert len(converted.rydberg_kets) == 1
+    assert np.allclose(converted.coefficients, [1.0])
+    assert np.isclose(ls_state.calc_reduced_overlap(converted), 1.0)
+
+
+def test_conversion_preserves_norm_energy_and_nu(
+    ls_state: RydbergStateSQDT[Any], coupling_scheme: CouplingScheme
+) -> None:
+    converted = ls_state.to_coupling_scheme(coupling_scheme)
+
+    assert np.isclose(converted.norm, 1.0)
+    assert converted.species == ls_state.species
+    assert np.isclose(converted.nu, ls_state.nu)
+    assert np.isclose(converted.get_energy("a.u."), ls_state.get_energy("a.u."))
+
+
+def test_converted_kets_live_in_the_target_scheme(
+    ls_state: RydbergStateSQDT[Any], coupling_scheme: CouplingScheme
+) -> None:
+    converted = ls_state.to_coupling_scheme(coupling_scheme)
+    assert all(ket.angular.coupling_scheme == coupling_scheme for ket in converted.rydberg_kets)
+
+
+def test_conversion_preserves_physical_state(ls_state: RydbergStateSQDT[Any], coupling_scheme: CouplingScheme) -> None:
+    """A coupling-scheme change is a unitary rotation of the angular basis: the state is unchanged."""
+    converted = ls_state.to_coupling_scheme(coupling_scheme)
+    assert np.isclose(ls_state.calc_reduced_overlap(converted), 1.0)
+
+
+def test_good_quantum_number_expectation_value_is_preserved(
+    ls_state: RydbergStateSQDT[Any], coupling_scheme: CouplingScheme
+) -> None:
+    # f_tot is a good quantum number, so it must survive the basis rotation
+    converted = ls_state.to_coupling_scheme(coupling_scheme)
+    assert np.isclose(converted.calc_exp_qn("f_tot"), ls_state.calc_exp_qn("f_tot"))
+
+
+# --------------------------------------------------------------------------------------
+# the concrete LS <-> JJ expansion
+# --------------------------------------------------------------------------------------
+
+
+def test_ls_to_jj_expands_with_clebsch_gordan_coefficients(ls_state: RydbergStateSQDT[Any]) -> None:
+    """3P1 in LS is a superposition of two JJ channels (j_r=1/2 and j_r=3/2)."""
+    jj = ls_state.to_coupling_scheme("JJ")
+
+    assert len(jj.rydberg_kets) == 2
+    # coefficients are sqrt(2/3) and sqrt(1/3) (up to ordering)
+    assert np.allclose(sorted(jj.coefficients), sorted([np.sqrt(1 / 3), np.sqrt(2 / 3)]))
+    assert np.isclose(np.sum(jj.coefficients**2), 1.0)
+
+
+def test_roundtrip_recovers_original_state(ls_state: RydbergStateSQDT[Any]) -> None:
+    roundtrip = ls_state.to_coupling_scheme("JJ").to_coupling_scheme("LS")
+
+    # the physical state is recovered exactly (up to zero-weight channels that the
+    # back-conversion may spuriously generate, e.g. the singlet 1P1 partner of 3P1)
+    assert np.isclose(ls_state.calc_reduced_overlap(roundtrip), 1.0)
+    assert np.isclose(np.max(roundtrip.coefficients), 1.0)
+    assert np.isclose(np.sum(roundtrip.coefficients**2), 1.0)
+
+
+def test_cancelling_channels_are_dropped(ls_state: RydbergStateSQDT[Any]) -> None:
+    """The near-cancellation guard (radial norm < 1e-12) must drop spuriously generated channels.
+
+    Converting 3P1 (LS) to JJ and back re-expands each JJ channel into LS components; the singlet
+    1P1 partner of 3P1 cancels to ~0 across the two JJ channels. Without the guard the conversion
+    would emit a bogus extra ket with a numerically-zero radial wavefunction, so asserting the exact
+    ket count pins the guard down (this test fails if the ``norm < 1e-12`` skip is removed).
+    """
+    roundtrip = ls_state.to_coupling_scheme("JJ").to_coupling_scheme("LS")
+
+    assert len(roundtrip.rydberg_kets) == 1
+
+
+def test_calc_exp_qn_uses_conversion_for_foreign_quantum_number(ls_state: RydbergStateSQDT[Any]) -> None:
+    """`j_r` is not defined in the LS scheme, so calc_exp_qn must convert to JJ internally."""
+    assert "j_r" not in ls_state.rydberg_kets[0].angular.quantum_number_names
+
+    exp_via_calc = ls_state.calc_exp_qn("j_r")
+    exp_via_manual_conversion = ls_state.to_coupling_scheme("JJ").angular_state.calc_exp_qn("j_r")
+    assert np.isclose(exp_via_calc, exp_via_manual_conversion)
+
+
+# --------------------------------------------------------------------------------------
+# multi-channel (MQDT) states: exercises the radial-combination (+=) branch
+# --------------------------------------------------------------------------------------
+
+
+def test_mqdt_multichannel_conversion_preserves_state(mqdt_basis: BasisMQDT, coupling_scheme: CouplingScheme) -> None:
+    multichannel = [state for state in mqdt_basis.states if len(state.rydberg_kets) > 1]
+    assert multichannel, "expected some multi-channel MQDT states in the basis"
+
+    for state in multichannel:
+        converted = state.to_coupling_scheme(coupling_scheme)
+        assert np.isclose(converted.norm, 1.0)
+        assert np.isclose(state.calc_reduced_overlap(converted), 1.0)
+        assert all(ket.angular.coupling_scheme == coupling_scheme for ket in converted.rydberg_kets)
+
+
+def test_mqdt_conversion_combines_shared_channels(mqdt_basis: BasisMQDT) -> None:
+    """When independent channels map onto a shared angular ket, their radial wavefunctions are summed.
+
+    Such a conversion produces fewer kets than the naive sum of the per-channel expansions, which
+    exercises the radial-wavefunction summation (``+=``) branch of ``to_coupling_scheme``. This
+    intrinsically scans all schemes at once, so it is not parametrized by the ``coupling_scheme`` fixture.
+    """
+    multichannel = [state for state in mqdt_basis.states if len(state.rydberg_kets) > 1]
+    assert multichannel, "expected some multi-channel MQDT states in the basis"
+
+    for state in multichannel:
+        for scheme in ("LS", "JJ", "FJ"):
+            converted = state.to_coupling_scheme(scheme)
+            naive_number_of_kets = sum(len(ket.angular.to_state(scheme).kets) for ket in state.rydberg_kets)
+            if len(converted.rydberg_kets) < naive_number_of_kets:
+                return  # found a conversion that merged channels -> the += branch ran
+
+    pytest.fail("expected at least one conversion to merge channels onto a shared angular ket")


### PR DESCRIPTION
- add a base `Radial` class, which also allows adding radial wavefunctions
- add `RadialDummy` to replace `PotentialDummy`
- allow to create base class objects of `RydbergState`
- `RydbergState` add `to_coupling_scheme` method
- update `RydbergState.calc_exp_qn` method to use the `to_coupling_scheme` method (this fixes a bug in calculating exp and std of quantum numbers of RydbergStates)