### PR TITLE
Add core matrix element

### DIFF
--- a/src/rydstate/angular/angular_ket.py
+++ b/src/rydstate/angular/angular_ket.py
@@ -658,6 +658,8 @@ class AngularKetBase(ABC, Generic[GenericT_Unknown], metaclass=CachedABCMeta):
         qn_name: AngularMomentumQuantumNumbers
         if operator == "spherical":
             qn_name = "l_r"
+        elif operator == "spherical_core":
+            qn_name = "l_c"
         elif operator in self.quantum_number_names:
             if kappa != 1:
                 raise ValueError("Only kappa=1 is supported for spin operators.")
@@ -673,7 +675,7 @@ class AngularKetBase(ABC, Generic[GenericT_Unknown], metaclass=CachedABCMeta):
         if is_unknown(qn_self) or is_unknown(qn_other):
             return 0  # TODO, ignore Unknown contributions for now
 
-        if operator == "spherical":
+        if operator in ("spherical", "spherical_core"):
             complete_reduced_matrix_element = calc_reduced_spherical_matrix_element(qn_self, qn_other, kappa)  # type: ignore [arg-type]
         elif operator in self.quantum_number_names:
             complete_reduced_matrix_element = calc_reduced_spin_matrix_element(qn_self, qn_other)

--- a/src/rydstate/angular/utils.py
+++ b/src/rydstate/angular/utils.py
@@ -48,6 +48,7 @@ IdentityOperators = Literal[
 
 AngularOperatorType = Literal[
     "spherical",
+    "spherical_core",
     AngularMomentumQuantumNumbers,
     IdentityOperators,
 ]

--- a/src/rydstate/rydberg_state/rydberg_ket.py
+++ b/src/rydstate/rydberg_state/rydberg_ket.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
+from rydstate.angular.angular_ket import AngularKetLS
+from rydstate.angular.utils import is_unknown
+from rydstate.species.element_properties import get_element_properties
+from rydstate.species.sqdt import get_sqdt
 from rydstate.units import MatrixElementOperatorRanks, ureg
 
 if TYPE_CHECKING:
@@ -31,6 +35,7 @@ class RydbergKet:
     ) -> None:
         r"""Initialize the Rydberg state."""
         self.species = species
+        self.element_properties = get_element_properties(species)
         self.angular = angular
         self.radial = radial
 
@@ -56,7 +61,7 @@ class RydbergKet:
     @overload
     def calc_reduced_matrix_element(self, other: RydbergKet, operator: MatrixElementOperator, unit: str) -> float: ...
 
-    def calc_reduced_matrix_element(
+    def calc_reduced_matrix_element(  # noqa: C901, PLR0912
         self, other: RydbergKet, operator: MatrixElementOperator, unit: str | None = None
     ) -> PintFloat | float:
         r"""Calculate the reduced matrix element.
@@ -69,6 +74,9 @@ class RydbergKet:
         where \hat{O}^{(k_{angular})} is the operator of rank k_angular for which to calculate the matrix element.
         k_radial and k_angular are determined from the operator automatically.
 
+        For the "electric_dipole" operator, the matrix element of "electric_dipole_rydberg" and "electric_dipole_core"
+        are calculated separately and added together.
+
         Args:
             other: The other Rydberg state for which to calculate the matrix element.
             operator: The operator for which to calculate the matrix element.
@@ -80,6 +88,12 @@ class RydbergKet:
             The reduced matrix element for the given operator.
 
         """
+        if operator == "electric_dipole":
+            matrix_element = self.calc_reduced_matrix_element(other, "electric_dipole_rydberg", unit)
+            if self.element_properties.number_valence_electrons == 2:
+                matrix_element += self.calc_reduced_matrix_element(other, "electric_dipole_core", unit)
+            return matrix_element
+
         try:
             k_radial, k_angular = MatrixElementOperatorRanks[operator]
         except KeyError as err:
@@ -99,9 +113,13 @@ class RydbergKet:
             # as the same dimensionality as the Bohr magneton (mu = - mu_B (g_l l + g_s s_tot))
             # such that - mu * B (where the magnetic field B is given in dimension Tesla) is an energy
 
-        elif operator in ["electric_dipole", "electric_quadrupole", "electric_octupole", "electric_quadrupole_zero"]:
+        elif operator.startswith("electric_"):
+            angular_operator: Literal["spherical", "spherical_core"]
+            angular_operator = "spherical" if "core" not in operator else "spherical_core"
             # Electric multipole operator: p_{k,q} = e r^k_radial * sqrt(4pi / (2k+1)) * Y_{k_angular,q}(\theta, phi)
-            angular_matrix_element = self.angular.calc_reduced_matrix_element(other.angular, "spherical", k_angular)
+            angular_matrix_element = self.angular.calc_reduced_matrix_element(
+                other.angular, angular_operator, k_angular
+            )
             # Prefactor sqrt(4 pi / (2 k_angular + 1)) for the electric multipole operators, precomputed for performance
             prefactor = ELECTRIC_MULTIPOLE_PREFACTORS[k_angular]
 
@@ -109,10 +127,17 @@ class RydbergKet:
             raise NotImplementedError(f"Operator {operator} not implemented.")
 
         if angular_matrix_element == 0:
-            matrix_element = 0.0
-        else:
+            return 0
+
+        if "core" not in operator:
             radial_matrix_element = self.radial.calc_matrix_element(other.radial, k_radial, unit="a.u.")
-            matrix_element = prefactor * radial_matrix_element * angular_matrix_element
+            matrix_element = prefactor * angular_matrix_element * radial_matrix_element
+        else:
+            core_radial_matrix_element = self._calc_core_radial_matrix_element_au(other, k_radial)
+            if core_radial_matrix_element == 0:
+                return 0
+            rydberg_radial_overlap = self.radial.calc_overlap(other.radial)
+            matrix_element = prefactor * angular_matrix_element * core_radial_matrix_element * rydberg_radial_overlap
 
         if unit == "a.u.":
             return matrix_element
@@ -121,7 +146,7 @@ class RydbergKet:
         matrix_element_unit: PintFloat
         if operator == "magnetic_dipole":
             matrix_element_unit = radial_unit * ureg.Quantity(2, "bohr_magneton")
-        elif operator in ["electric_dipole", "electric_quadrupole", "electric_octupole", "electric_quadrupole_zero"]:
+        elif operator.startswith("electric_"):
             matrix_element_unit = radial_unit * ureg.Quantity(1, "e")
         else:
             raise NotImplementedError(f"Operator {operator} not implemented.")
@@ -129,6 +154,52 @@ class RydbergKet:
         if unit is None:
             return matrix_element * matrix_element_unit.to_base_units()  # type: ignore [no-any-return]
         return matrix_element * matrix_element_unit.to(unit).magnitude
+
+    def _calc_core_radial_matrix_element_au(self, other: RydbergKet, k_radial: int) -> float:
+        r"""Calculate the radial matrix element :math:`\langle self_c | r^{k_{radial}} | other_c \rangle` in a.u.
+
+        The core electron is treated as the low-lying valence electron of the corresponding singly charged SQDT ion
+        (e.g. Yb174_ion for Yb174):
+        the Rydberg electron is ignored and the radial matrix element is calculated between the two ion states,
+        where the principal quantum number of each core electron is given by the lowest allowed shell of the ion
+        for the given l_c.
+        """
+        from rydstate.rydberg_state.rydberg_sqdt import RydbergStateSQDT  # noqa: PLC0415
+
+        species = self.species
+        ion_species = f"{species}_ion"
+        try:
+            ion_sqdt = get_sqdt(ion_species)
+        except ValueError:
+            logger.warning(
+                "No SQDT data available for the ion species of %s "
+                "returning 0 for the dipole matrix element core contribution.",
+                species,
+            )
+            return 0.0
+
+        kets = {"self": self, "other": other}
+        ion_states: dict[str, RydbergStateSQDT[Any]] = {}
+        for ket_name, ket in kets.items():
+            l_c = ket.angular.l_c
+            j_c = ket.angular.get_qn("j_c", allow_unknown=True)
+            f_c = ket.angular.get_qn("f_c", allow_unknown=True)
+            if is_unknown(l_c) or is_unknown(j_c) or is_unknown(f_c):
+                return 0.0
+
+            angular_ket = AngularKetLS(l_r=l_c, j_tot=j_c, f_tot=f_c, species=ion_species)
+
+            # TODO: we should probably also store n_c for the core angular ket in the future
+            # for now, it is correct to assume that the core electron is
+            # in the lowest allowed shell of the ion for the given l_c
+            for n_c in range(l_c + 1, l_c + 15):
+                if ion_sqdt.is_allowed_shell(n_c, l_c, 0.5):
+                    ion_states[ket_name] = RydbergStateSQDT(ion_species, n_c, angular_ket=angular_ket, sqdt=ion_sqdt)
+                    break
+            else:  # no break
+                raise ValueError(f"No allowed shell found for ion species {ion_species} with l_c={l_c}.")
+
+        return ion_states["self"].radial.calc_matrix_element(ion_states["other"].radial, k_radial, unit="a.u.")
 
     @overload
     def calc_matrix_element(

--- a/src/rydstate/rydberg_state/rydberg_ket.py
+++ b/src/rydstate/rydberg_state/rydberg_ket.py
@@ -61,7 +61,7 @@ class RydbergKet:
     @overload
     def calc_reduced_matrix_element(self, other: RydbergKet, operator: MatrixElementOperator, unit: str) -> float: ...
 
-    def calc_reduced_matrix_element(  # noqa: C901, PLR0912
+    def calc_reduced_matrix_element(
         self, other: RydbergKet, operator: MatrixElementOperator, unit: str | None = None
     ) -> PintFloat | float:
         r"""Calculate the reduced matrix element.
@@ -88,10 +88,30 @@ class RydbergKet:
             The reduced matrix element for the given operator.
 
         """
+        matrix_element_au = self._calc_reduced_matrix_element_au(other, operator)
+
+        if unit == "a.u.":
+            return matrix_element_au
+
+        k_radial, _k_angular = MatrixElementOperatorRanks[operator]
+        radial_unit: PintFloat = ureg.Quantity(1, "bohr_radius") ** k_radial
+        matrix_element_unit: PintFloat
+        if operator == "magnetic_dipole":
+            matrix_element_unit = radial_unit * ureg.Quantity(2, "bohr_magneton")
+        elif operator.startswith("electric_"):
+            matrix_element_unit = radial_unit * ureg.Quantity(1, "e")
+        else:
+            raise NotImplementedError(f"Operator {operator} not implemented.")
+
+        if unit is None:
+            return matrix_element_au * matrix_element_unit.to_base_units()  # type: ignore [no-any-return]
+        return matrix_element_au * matrix_element_unit.to(unit).magnitude
+
+    def _calc_reduced_matrix_element_au(self, other: RydbergKet, operator: MatrixElementOperator) -> float:
         if operator == "electric_dipole":
-            matrix_element = self.calc_reduced_matrix_element(other, "electric_dipole_rydberg", unit)
+            matrix_element = self._calc_reduced_matrix_element_au(other, "electric_dipole_rydberg")
             if self.element_properties.number_valence_electrons == 2:
-                matrix_element += self.calc_reduced_matrix_element(other, "electric_dipole_core", unit)
+                matrix_element += self._calc_reduced_matrix_element_au(other, "electric_dipole_core")
             return matrix_element
 
         try:
@@ -127,7 +147,7 @@ class RydbergKet:
             raise NotImplementedError(f"Operator {operator} not implemented.")
 
         if angular_matrix_element == 0:
-            return 0
+            return 0.0
 
         if "core" not in operator:
             radial_matrix_element = self.radial.calc_matrix_element(other.radial, k_radial, unit="a.u.")
@@ -135,25 +155,11 @@ class RydbergKet:
         else:
             core_radial_matrix_element = self._calc_core_radial_matrix_element_au(other, k_radial)
             if core_radial_matrix_element == 0:
-                return 0
+                return 0.0
             rydberg_radial_overlap = self.radial.calc_overlap(other.radial)
             matrix_element = prefactor * angular_matrix_element * core_radial_matrix_element * rydberg_radial_overlap
 
-        if unit == "a.u.":
-            return matrix_element
-
-        radial_unit: PintFloat = ureg.Quantity(1, "bohr_radius") ** k_radial
-        matrix_element_unit: PintFloat
-        if operator == "magnetic_dipole":
-            matrix_element_unit = radial_unit * ureg.Quantity(2, "bohr_magneton")
-        elif operator.startswith("electric_"):
-            matrix_element_unit = radial_unit * ureg.Quantity(1, "e")
-        else:
-            raise NotImplementedError(f"Operator {operator} not implemented.")
-
-        if unit is None:
-            return matrix_element * matrix_element_unit.to_base_units()  # type: ignore [no-any-return]
-        return matrix_element * matrix_element_unit.to(unit).magnitude
+        return matrix_element
 
     def _calc_core_radial_matrix_element_au(self, other: RydbergKet, k_radial: int) -> float:
         r"""Calculate the radial matrix element :math:`\langle self_c | r^{k_{radial}} | other_c \rangle` in a.u.

--- a/src/rydstate/units.py
+++ b/src/rydstate/units.py
@@ -21,6 +21,8 @@ ureg: UnitRegistry[float] = UnitRegistry(system="atomic")
 MatrixElementOperator = Literal[
     "magnetic_dipole",
     "electric_dipole",
+    "electric_dipole_rydberg",
+    "electric_dipole_core",
     "electric_quadrupole",
     "electric_octupole",
     "electric_quadrupole_zero",
@@ -28,7 +30,9 @@ MatrixElementOperator = Literal[
 MatrixElementOperatorRanks: dict[MatrixElementOperator, tuple[int, int]] = {
     # "operator": (k_radial, k_angular)
     "magnetic_dipole": (0, 1),
-    "electric_dipole": (1, 1),
+    "electric_dipole": (1, 1),  # composed of "electric_dipole_rydberg" and "electric_dipole_core"
+    "electric_dipole_rydberg": (1, 1),
+    "electric_dipole_core": (1, 1),
     "electric_quadrupole": (2, 2),
     "electric_octupole": (3, 3),
     "electric_quadrupole_zero": (2, 0),

--- a/tests/test_rydberg_state_mqdt.py
+++ b/tests/test_rydberg_state_mqdt.py
@@ -130,3 +130,31 @@ def test_matrix_element_between_mqdt_and_sqdt_state(basis: BasisMQDT) -> None:
     me = s_mqdt.calc_reduced_matrix_element(p_sqdt, "electric_dipole", unit="e a0")
     assert np.isfinite(me)
     assert abs(me) > 0.0
+
+
+@pytest.mark.parametrize(
+    ("species", "f_tot_soi", "f_tot_low"),
+    [("Yb174", 0.0, (0.0, 1.0)), ("Yb171", 0.5, (0.5, 1.5))],
+)
+def test_core_dipole_comparable_to_rydberg_dipole(
+    species: str, f_tot_soi: float, f_tot_low: tuple[float, float]
+) -> None:
+    low_lying = BasisMQDT(species, nu=(0, 4), l_r=(1, 1), f_tot=f_tot_low)
+    state_of_interest = BasisMQDT(species, nu=(40, 50), l_r=(0, 0), f_tot=(f_tot_soi, f_tot_soi)).states[0]
+
+    ratios = []
+    for low in low_lying.states:
+        core = low.calc_reduced_matrix_element(state_of_interest, "electric_dipole_core", unit="e a0")
+        rydberg = low.calc_reduced_matrix_element(state_of_interest, "electric_dipole_rydberg", unit="e a0")
+        assert np.isfinite(core)
+        assert np.isfinite(rydberg)
+        # collect states with a sizeable core dipole that also have a sizeable Rydberg dipole
+        if abs(core) > 1e-3 and abs(rydberg) > 1e-3:
+            ratios.append(abs(core) / abs(rydberg))
+
+    # at least one low-lying state has a non-negligible core dipole ...
+    assert ratios, f"no low-lying state with a sizeable core dipole found for {species}"
+    # ... and for at least one of them the core dipole is comparable (within an order of magnitude)
+    assert any(0.1 < ratio < 10 for ratio in ratios), (
+        f"core dipole not comparable to rydberg dipole for {species}: |core/rydberg| ratios={ratios}"
+    )


### PR DESCRIPTION
For divalent atoms using MQDT it might be that the core electron can have a dipole transition, which especially for transitions including low-nu states become relevant. (e.g. for Yb (|6sns> + epsilon |6p6p>) -> |6s6p>

### TODO for future PRs
- n_c should probably be stored within angular ket for core excitations?
- check again if the sign of radial matrix element is correct, and pin it with a test,...
- add strontium and check against Vaillant