### PR TITLE
remove reference_core_ket, always use lowest ionization threshold

### DIFF
--- a/src/rydstate/species/mqdt.py
+++ b/src/rydstate/species/mqdt.py
@@ -30,10 +30,6 @@ class MQDT(ABC, metaclass=CachedABCMeta):
     """Dictionary containing the ionization thresholds for the different core states.
     The thresholds are given in the form of a tuple (ionization_threshold, unit).
     """
-    reference_core_ket: ClassVar[CoreKet | None] = None
-    """The core ket to use as reference for the ionization energy.
-    If None, the reference ionization energy is defined as the smallest ionization energy
-    in the ionization_threshold_dict."""
 
     model_classes: ClassVar[list[type[FModel]]]
     """List of the MQDT :class:`~rydstate.species.fmodel.FModel` models available for this species.
@@ -83,11 +79,9 @@ class MQDT(ABC, metaclass=CachedABCMeta):
     def reference_ionization_energy_au(self) -> float:
         """Reference ionization energy in atomic units (Hartree).
 
-        If no reference_core_ket is defined, we define the reference ionization energy as the smallest ionization energy
-        in the ionization_threshold_dict.
+        The reference ionization energy is defined as the smallest ionization energy
+        in the ionization_threshold_dict, i.e. the lowest (energetically first) ionization threshold.
         """
-        if self.reference_core_ket is not None:
-            return self.get_ionization_threshold(self.reference_core_ket, unit="a.u.")
         return min(self.get_ionization_threshold(core_ket, unit="a.u.") for core_ket in self.ionization_threshold_dict)
 
     def get_mqdt_models(self, outer_channel: AngularKetFJ[Any]) -> list[FModel]:

--- a/src/rydstate/species/strontium/mqdt_data.py
+++ b/src/rydstate/species/strontium/mqdt_data.py
@@ -16,7 +16,6 @@ class MQDTStrontium87(MQDT):
         CoreKet(4.5, 0.5, 0, 0.5, 4): (45932.287373577, "1/cm"),
         CoreKet(4.5, 0.5, 0, 0.5, 5): (45932.120512528, "1/cm"),
     }
-    reference_core_ket = CoreKet(4.5, 0.5, 0, 0.5, 4)
     model_classes = get_fmodels(sr87_mqdt_fmodel_data, species)
 
 

--- a/src/rydstate/species/ytterbium/mqdt_data.py
+++ b/src/rydstate/species/ytterbium/mqdt_data.py
@@ -25,7 +25,6 @@ class MQDTYtterbium171(MQDT):
         CoreKet(0.5, 0.5, 1, 1.5, Unknown, label=Unknown): (80835.39, "1/cm"),
         CoreKet(0.5, 0.5, Unknown, Unknown, Unknown, label="4f13 5d 6s"): (83967.7, "1/cm"),
     }
-    reference_core_ket = CoreKet(0.5, 0.5, 0, 0.5, 1)
     model_classes = get_fmodels(yb171_mqdt_fmodel_data, species)
 
 
@@ -40,7 +39,6 @@ class MQDTYtterbium173(MQDT):
         CoreKet(2.5, 0.5, 1, 1.5, Unknown, label=Unknown): (80835.39, "1/cm"),
         CoreKet(2.5, 0.5, Unknown, Unknown, Unknown, label="4f13 5d 6s"): (83967.7, "1/cm"),
     }
-    reference_core_ket = CoreKet(2.5, 0.5, 0, 0.5, 2)
     model_classes = get_fmodels(yb173_mqdt_fmodel_data, species)
 
 


### PR DESCRIPTION
# TODO
not sure if we want this, if the quantum defects where fitted with the reference ionization threshold, this might slightly change the calculated energies, ...